### PR TITLE
feat: calendar management UI + school day generation

### DIFF
--- a/docs/business-logic/01-schedule-and-calendar.md
+++ b/docs/business-logic/01-schedule-and-calendar.md
@@ -8,48 +8,53 @@ City View itself does not use A/B rotation — every school day is the same from
 
 Rotation day values are stored in `school_days.rotation_day` and validated in the application layer against `organization.settings.rotation_day_names` (defaults to `["A", "B"]`).
 
-**Algorithm:**
+**Algorithm (per-reason advancement):**
+
+The rotation advances based on the `override_reason` of non-school days, not a global toggle:
+
+- **School days** (`is_school_day = true`): always advance the rotation
+- **Unscheduled cancellations** (`weather`, `emergency`): advance the rotation (the day "counts" even though school didn't happen)
+- **Planned holidays** (`planned_holiday`): do NOT advance the rotation (rotation pauses)
+
+The former `rotation_mode` setting (`continue`/`repeat`) is deprecated and ignored.
 
 ```
 function calculateRotationDay(date, organization):
-  // Orgs that don't use rotation have no rotation days
   if not organization.settings.uses_rotation_schedule:
     return null
 
-  // Check for an explicit override on this date
   schoolDay = getSchoolDay(date, organization.id)
   if schoolDay and schoolDay.rotation_day is not null:
-    return schoolDay.rotation_day
+    return schoolDay.rotation_day  // explicit override
 
-  // Calculate from the term start using org settings
   term = getCurrentTerm(organization.id)
   allDays = getSchoolDaysInRange(term.start_date, date, organization.id)
 
-  if organization.settings.rotation_mode == "continue":
-    // Skip non-school days — rotation advances only on days school is in session
-    countableDays = allDays.filter(d => d.is_school_day)
-  else: // "repeat"
-    // Cancelled days repeat — the rotation does not advance
-    countableDays = allDays
+  // Count days that advance the rotation
+  countableDays = allDays.filter(d =>
+    d.is_school_day or
+    d.override_reason == "weather" or
+    d.override_reason == "emergency"
+  )
 
   rotationNames = organization.settings.rotation_day_names  // e.g. ["A", "B"]
   index = countableDays.length % rotationNames.length
   return rotationNames[index]
 ```
 
-**Example — "continue" mode:**
+**Example:**
 
-Organization: `rotation_day_names: ["A", "B"]`, `rotation_mode: "continue"`, term starts Mon Jan 5 (A day)
+Organization: `rotation_day_names: ["A", "B"]`, term starts Mon Jan 5 (A day)
 
-| Date | School? | Rotation | Why |
-|------|---------|----------|-----|
-| Mon Jan 5 | Yes | A | Day 0 → index 0 |
-| Tue Jan 6 | Yes | B | Day 1 → index 1 |
-| Wed Jan 7 | Yes | A | Day 2 → index 0 |
-| Thu Jan 8 | Cancelled (weather) | — | Skipped in count |
-| Fri Jan 9 | Yes | B | Day 3 → index 1 (continues, doesn't repeat Thu) |
-
-If `rotation_mode` were `"repeat"`: Fri Jan 9 would be A (repeats Thu's cancelled slot).
+| Date | School? | Reason | Rotation | Why |
+|------|---------|--------|----------|-----|
+| Mon Jan 5 | Yes | — | A | Day 0 → index 0 |
+| Tue Jan 6 | Yes | — | B | Day 1 → index 1 |
+| Wed Jan 7 | Yes | — | A | Day 2 → index 0 |
+| Thu Jan 8 | No | weather | — | Counts (advances rotation) |
+| Fri Jan 9 | Yes | — | A | Day 3 → index 1... wait, 4 countable days → index 0 = A |
+| Mon Jan 12 | No | planned_holiday | — | Does NOT count (rotation pauses) |
+| Tue Jan 13 | Yes | — | B | Still index 1 (holiday didn't advance) |
 
 ---
 

--- a/docs/schema/01-core-tables.md
+++ b/docs/schema/01-core-tables.md
@@ -34,9 +34,7 @@ CREATE TABLE organizations (
 
 `block_count`: Number of blocks in the daily schedule. `null` means the org hasn't defined their block structure yet. Activities can still be created with `block = NULL` in this state. When set (e.g. `6`), the app validates that block assignments stay within `0` to `block_count - 1`.
 
-`rotation_mode`:
-- `"continue"` — cancelled school days are skipped in the rotation count (snow day on A day → next school day is B day)
-- `"repeat"` — cancelled days repeat (snow day on A day → next school day is also A day)
+`rotation_mode`: **Deprecated.** Ignored by application code. Rotation advancement is now determined per-reason: planned holidays pause the rotation, unscheduled cancellations (weather/emergency) advance it. See `docs/business-logic/01-schedule-and-calendar.md`. Left in existing JSONB data — no migration to remove it.
 
 ---
 

--- a/src/api/calendar.js
+++ b/src/api/calendar.js
@@ -1,54 +1,6 @@
 import { supabase } from './supabase'
 
-// Get the current academic term for an organization
-export async function getCurrentTerm(organizationId) {
-  const { data, error } = await supabase
-    .from('academic_terms')
-    .select('*')
-    .eq('organization_id', organizationId)
-    .eq('is_current', true)
-    .single()
-
-  if (error) throw error
-  return data
-}
-
-// Get all terms for an organization
-export async function getTerms(organizationId) {
-  const { data, error } = await supabase
-    .from('academic_terms')
-    .select('*')
-    .eq('organization_id', organizationId)
-    .order('start_date', { ascending: false })
-
-  if (error) throw error
-  return data
-}
-
-// Create a new term
-export async function createTerm(term) {
-  const { data, error } = await supabase
-    .from('academic_terms')
-    .insert(term)
-    .select()
-    .single()
-
-  if (error) throw error
-  return data
-}
-
-// Update a term
-export async function updateTerm(termId, updates) {
-  const { data, error } = await supabase
-    .from('academic_terms')
-    .update(updates)
-    .eq('id', termId)
-    .select()
-    .single()
-
-  if (error) throw error
-  return data
-}
+// Term CRUD functions are in terms.js — this file handles school days and schedule templates.
 
 // Get the school day record for a specific date
 export async function getSchoolDay(organizationId, date) {
@@ -98,6 +50,18 @@ export async function bulkUpsertSchoolDays(schoolDays) {
 
   if (error) throw error
   return data
+}
+
+// Delete school days in a date range (for term deletion/shrinking)
+export async function deleteSchoolDaysInRange(organizationId, startDate, endDate) {
+  const { error } = await supabase
+    .from('school_days')
+    .delete()
+    .eq('organization_id', organizationId)
+    .gte('date', startDate)
+    .lte('date', endDate)
+
+  if (error) throw error
 }
 
 // Get all schedule templates for an organization

--- a/src/components/calendar/CalendarGrid.jsx
+++ b/src/components/calendar/CalendarGrid.jsx
@@ -1,0 +1,349 @@
+import { useState, useMemo } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa'
+import { useSchoolDays } from '@/hooks/useSchoolDays'
+import { upsertSchoolDay, bulkUpsertSchoolDays, getSchoolDays } from '@/api/calendar'
+import { recalculateRotationDays } from '@/lib/business-logic/rotation'
+import { getWeekdaysInRange } from '@/lib/business-logic/schoolDayGeneration'
+import DayPopover from './DayPopover'
+
+const WEEKDAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri']
+
+// Fixed rotation label colors by index
+const ROTATION_COLORS = [
+  'text-blue-600',
+  'text-green-600',
+  'text-purple-600',
+  'text-orange-600',
+]
+
+function getMonthRange(year, month) {
+  const start = new Date(year, month, 1)
+  const end = new Date(year, month + 1, 0)
+  return {
+    startDate: start.toISOString().slice(0, 10),
+    endDate: end.toISOString().slice(0, 10),
+    year: start.getFullYear(),
+    month: start.getMonth(),
+  }
+}
+
+function getMonthLabel(year, month) {
+  const d = new Date(year, month, 1)
+  return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
+}
+
+function getTodayStr() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+/**
+ * Build the grid of weekday cells for a given month.
+ * Returns an array of weeks, each containing 5 cells (Mon-Fri).
+ * Cells may be null (padding before/after month days).
+ */
+function buildMonthGrid(year, month) {
+  const lastDay = new Date(year, month + 1, 0)
+  const daysInMonth = lastDay.getDate()
+
+  const weeks = []
+  let currentWeek = [null, null, null, null, null]
+  let hasContent = false
+
+  for (let day = 1; day <= daysInMonth; day++) {
+    const date = new Date(year, month, day)
+    const dow = date.getDay() // 0=Sun, 1=Mon, ..., 6=Sat
+
+    // Skip weekends
+    if (dow === 0 || dow === 6) continue
+
+    const weekdayIndex = dow - 1 // 0=Mon, 1=Tue, ..., 4=Fri
+
+    // If this weekday is earlier than or same as what we've seen, start a new week
+    if (hasContent && weekdayIndex === 0) {
+      weeks.push(currentWeek)
+      currentWeek = [null, null, null, null, null]
+    }
+
+    currentWeek[weekdayIndex] = {
+      day,
+      date: date.toISOString().slice(0, 10),
+    }
+    hasContent = true
+  }
+
+  // Push the last week if it has content
+  if (hasContent) {
+    weeks.push(currentWeek)
+  }
+
+  return weeks
+}
+
+function getDayStatus(schoolDay) {
+  if (!schoolDay) return 'outside' // no school_days row
+  if (schoolDay.is_school_day) return 'school'
+  return schoolDay.override_reason || 'cancelled'
+}
+
+function getDayCellClasses(status, isToday) {
+  let bg = ''
+  switch (status) {
+    case 'school':
+      bg = 'bg-base-100'
+      break
+    case 'planned_holiday':
+      bg = 'bg-base-200 text-base-content/50'
+      break
+    case 'weather':
+      bg = 'bg-amber-50'
+      break
+    case 'emergency':
+      bg = 'bg-red-50'
+      break
+    case 'outside':
+      bg = 'bg-transparent'
+      break
+    default:
+      bg = 'bg-base-200'
+  }
+
+  const todayRing = isToday ? 'ring-2 ring-blue-400' : ''
+  return `${bg} ${todayRing}`
+}
+
+export default function CalendarGrid({ orgId, orgSettings, terms }) {
+  const today = getTodayStr()
+  const [viewDate, setViewDate] = useState(() => {
+    const now = new Date()
+    return { year: now.getFullYear(), month: now.getMonth() }
+  })
+  const [popover, setPopover] = useState(null) // { date, anchorRect }
+
+  const queryClient = useQueryClient()
+  const { startDate, endDate } = getMonthRange(viewDate.year, viewDate.month)
+  const { data: schoolDays = [] } = useSchoolDays(orgId, startDate, endDate)
+
+  const schoolDayMap = useMemo(() => {
+    return new Map(schoolDays.map(d => [d.date, d]))
+  }, [schoolDays])
+
+  const rotationColorMap = useMemo(() => {
+    const names = orgSettings?.rotation_day_names || ['A', 'B']
+    const map = {}
+    names.forEach((name, i) => {
+      map[name] = ROTATION_COLORS[i % ROTATION_COLORS.length]
+    })
+    return map
+  }, [orgSettings?.rotation_day_names])
+
+  const weeks = useMemo(
+    () => buildMonthGrid(viewDate.year, viewDate.month),
+    [viewDate.year, viewDate.month]
+  )
+
+  function prevMonth() {
+    setViewDate(prev => {
+      const d = new Date(prev.year, prev.month - 1, 1)
+      return { year: d.getFullYear(), month: d.getMonth() }
+    })
+    setPopover(null)
+  }
+
+  function nextMonth() {
+    setViewDate(prev => {
+      const d = new Date(prev.year, prev.month + 1, 1)
+      return { year: d.getFullYear(), month: d.getMonth() }
+    })
+    setPopover(null)
+  }
+
+  function goToToday() {
+    const now = new Date()
+    setViewDate({ year: now.getFullYear(), month: now.getMonth() })
+    setPopover(null)
+  }
+
+  function handleDayClick(cell, e) {
+    if (!cell) return
+    const rect = e.currentTarget.getBoundingClientRect()
+    setPopover(prev =>
+      prev?.date === cell.date ? null : { date: cell.date, anchorRect: rect }
+    )
+  }
+
+  // Find the term that contains a given date (for rotation recalculation scope)
+  function findTermForDate(dateStr) {
+    return terms?.find(t => dateStr >= t.start_date && dateStr <= t.end_date)
+  }
+
+  async function handleMarkDayOff(date, reason, notes) {
+    const existing = schoolDayMap.get(date)
+    await upsertSchoolDay({
+      organization_id: orgId,
+      date,
+      is_school_day: false,
+      override_reason: reason,
+      notes: notes || null,
+      rotation_day: null,
+      ...(existing?.id ? { id: existing.id } : {}),
+    })
+
+    // Recalculate rotation for the term containing this date
+    await recalculateTermRotation(date)
+    queryClient.invalidateQueries({ queryKey: ['school-days', orgId] })
+    setPopover(null)
+  }
+
+  async function handleRestoreSchoolDay(date) {
+    const existing = schoolDayMap.get(date)
+    if (!existing) return
+
+    await upsertSchoolDay({
+      ...existing,
+      is_school_day: true,
+      override_reason: null,
+      notes: null,
+    })
+
+    await recalculateTermRotation(date)
+    queryClient.invalidateQueries({ queryKey: ['school-days', orgId] })
+    setPopover(null)
+  }
+
+  async function handleMarkRange(startDateStr, endDateStr, reason, notes) {
+    const weekdays = getWeekdaysInRange(startDateStr, endDateStr)
+    const rows = weekdays.map(date => {
+      const existing = schoolDayMap.get(date)
+      return {
+        organization_id: orgId,
+        date,
+        is_school_day: false,
+        override_reason: reason,
+        notes: notes || null,
+        rotation_day: null,
+        ...(existing?.id ? { id: existing.id } : {}),
+      }
+    })
+
+    if (rows.length > 0) {
+      await bulkUpsertSchoolDays(rows)
+    }
+
+    await recalculateTermRotation(startDateStr)
+    queryClient.invalidateQueries({ queryKey: ['school-days', orgId] })
+    setPopover(null)
+  }
+
+  async function recalculateTermRotation(dateStr) {
+    const term = findTermForDate(dateStr)
+    if (!term || !orgSettings?.uses_rotation_schedule) return
+
+    const allDays = await getSchoolDays(orgId, term.start_date, term.end_date)
+    const updates = recalculateRotationDays(allDays, orgSettings)
+    if (updates.length > 0) {
+      await bulkUpsertSchoolDays(updates)
+    }
+  }
+
+  return (
+    <div className="card bg-base-100 shadow-sm border border-base-300">
+      <div className="card-body">
+        {/* Header with navigation */}
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="card-title text-lg">School Calendar</h3>
+          <div className="flex items-center gap-1">
+            <button className="btn btn-ghost btn-xs" onClick={prevMonth}>
+              <FaChevronLeft size={10} />
+            </button>
+            <button
+              className="btn btn-ghost btn-xs font-medium min-w-25"
+              onClick={goToToday}
+              title="Go to current month"
+            >
+              {getMonthLabel(viewDate.year, viewDate.month)}
+            </button>
+            <button className="btn btn-ghost btn-xs" onClick={nextMonth}>
+              <FaChevronRight size={10} />
+            </button>
+          </div>
+        </div>
+
+        {/* Weekday headers */}
+        <div className="grid grid-cols-5 gap-1 mb-1">
+          {WEEKDAY_LABELS.map(label => (
+            <div key={label} className="text-center text-xs font-medium text-base-content/50 py-1">
+              {label}
+            </div>
+          ))}
+        </div>
+
+        {/* Day grid */}
+        <div className="space-y-1">
+          {weeks.map((week, wi) => (
+            <div key={wi} className="grid grid-cols-5 gap-1">
+              {week.map((cell, ci) => {
+                if (!cell) {
+                  return <div key={ci} className="aspect-square" />
+                }
+
+                const schoolDay = schoolDayMap.get(cell.date)
+                const status = getDayStatus(schoolDay)
+                const isToday = cell.date === today
+                const cellClasses = getDayCellClasses(status, isToday)
+                const rotationDay = schoolDay?.rotation_day
+                const rotationColor = rotationDay ? (rotationColorMap[rotationDay] || 'text-base-content/60') : ''
+
+                return (
+                  <button
+                    key={ci}
+                    className={`aspect-square rounded-lg flex flex-col items-center justify-center cursor-pointer hover:ring-1 hover:ring-base-300 transition-colors ${cellClasses} ${status === 'outside' ? 'text-base-content/30' : ''}`}
+                    onClick={(e) => handleDayClick(cell, e)}
+                    title={cell.date}
+                  >
+                    <span className="text-sm font-medium leading-none">{cell.day}</span>
+                    {rotationDay && (
+                      <span className={`text-[10px] font-bold leading-none mt-0.5 ${rotationColor}`}>
+                        {rotationDay}
+                      </span>
+                    )}
+                  </button>
+                )
+              })}
+            </div>
+          ))}
+        </div>
+
+        {/* Legend */}
+        <div className="flex flex-wrap gap-3 mt-3 text-xs text-base-content/60">
+          <span className="flex items-center gap-1">
+            <span className="w-3 h-3 rounded bg-base-100 border border-base-300" /> School
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-3 h-3 rounded bg-base-200" /> Holiday
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-3 h-3 rounded bg-amber-50 border border-amber-200" /> Weather
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-3 h-3 rounded bg-red-50 border border-red-200" /> Emergency
+          </span>
+        </div>
+      </div>
+
+      {/* Day Popover */}
+      {popover && (
+        <DayPopover
+          date={popover.date}
+          anchorRect={popover.anchorRect}
+          schoolDay={schoolDayMap.get(popover.date) || null}
+          orgSettings={orgSettings}
+          onMarkDayOff={handleMarkDayOff}
+          onRestoreSchoolDay={handleRestoreSchoolDay}
+          onMarkRange={handleMarkRange}
+          onClose={() => setPopover(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/calendar/DayPopover.jsx
+++ b/src/components/calendar/DayPopover.jsx
@@ -1,0 +1,242 @@
+import { useState, useEffect, useRef } from 'react'
+import { OVERRIDE_REASON_LABELS } from '@/lib/constants'
+
+const REASONS = [
+  { value: 'planned_holiday', label: 'Planned holiday' },
+  { value: 'weather', label: 'Weather' },
+  { value: 'emergency', label: 'Emergency' },
+]
+
+function formatDateDisplay(dateStr) {
+  const d = new Date(dateStr + 'T00:00:00')
+  return d.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+export default function DayPopover({
+  date,
+  anchorRect,
+  schoolDay,
+  onMarkDayOff,
+  onRestoreSchoolDay,
+  onMarkRange,
+  onClose,
+}) {
+  const [mode, setMode] = useState('single') // 'single' | 'range'
+  const [reason, setReason] = useState('planned_holiday')
+  const [notes, setNotes] = useState('')
+  const [endDate, setEndDate] = useState(date)
+  const [saving, setSaving] = useState(false)
+  const popoverRef = useRef(null)
+
+  // Close on outside click
+  useEffect(() => {
+    function handleClick(e) {
+      if (popoverRef.current && !popoverRef.current.contains(e.target)) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [onClose])
+
+  // Reset form when date changes
+  useEffect(() => {
+    setMode('single')
+    setReason(schoolDay?.override_reason || 'planned_holiday')
+    setNotes(schoolDay?.notes || '')
+    setEndDate(date)
+    setSaving(false)
+  }, [date, schoolDay])
+
+  const isSchoolDay = schoolDay?.is_school_day === true
+  const isException = schoolDay && !schoolDay.is_school_day
+  const isOutside = !schoolDay
+
+  async function handleSaveSingle() {
+    setSaving(true)
+    try {
+      await onMarkDayOff(date, reason, notes)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleSaveRange() {
+    if (endDate < date) return
+    setSaving(true)
+    try {
+      await onMarkRange(date, endDate, reason, notes)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleRestore() {
+    setSaving(true)
+    try {
+      await onRestoreSchoolDay(date)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  // Position the popover relative to the anchor
+  const style = {}
+  if (anchorRect) {
+    // Position below and centered on the clicked cell
+    style.position = 'fixed'
+    style.top = anchorRect.bottom + 4
+    style.left = Math.max(8, anchorRect.left + anchorRect.width / 2 - 150)
+    style.zIndex = 50
+
+    // Prevent overflow off right edge
+    if (typeof window !== 'undefined' && style.left + 300 > window.innerWidth) {
+      style.left = window.innerWidth - 308
+    }
+    // If it would go below viewport, position above instead
+    if (typeof window !== 'undefined' && style.top + 300 > window.innerHeight) {
+      style.top = anchorRect.top - 4
+      style.transform = 'translateY(-100%)'
+    }
+  }
+
+  return (
+    <div
+      ref={popoverRef}
+      className="card bg-base-100 shadow-xl border border-base-300 w-[300px]"
+      style={style}
+    >
+      <div className="card-body p-3 space-y-2">
+        {/* Date header */}
+        <div className="text-sm font-medium">{formatDateDisplay(date)}</div>
+
+        {/* Current status */}
+        <div className="text-xs text-base-content/60">
+          {isSchoolDay && 'School day'}
+          {isException && (
+            <>
+              {OVERRIDE_REASON_LABELS[schoolDay.override_reason] || 'Day off'}
+              {schoolDay.notes && <span className="italic ml-1">— {schoolDay.notes}</span>}
+            </>
+          )}
+          {isOutside && 'Outside term range'}
+        </div>
+
+        {/* Exception day — show restore and change options */}
+        {isException && (
+          <div className="space-y-2">
+            <button
+              className="btn btn-ghost btn-xs w-full justify-start"
+              onClick={handleRestore}
+              disabled={saving}
+            >
+              Restore school day
+            </button>
+
+            <div className="divider my-0 text-xs text-base-content/40">Change reason</div>
+            <ReasonAndNotesForm
+              reason={reason}
+              setReason={setReason}
+              notes={notes}
+              setNotes={setNotes}
+            />
+            <div className="flex justify-end gap-1">
+              <button className="btn btn-ghost btn-xs" onClick={onClose}>Cancel</button>
+              <button className="btn btn-primary btn-xs" onClick={handleSaveSingle} disabled={saving}>
+                {saving ? <span className="loading loading-spinner loading-xs" /> : 'Save'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* School day or outside — show mark off options */}
+        {(isSchoolDay || isOutside) && (
+          <div className="space-y-2">
+            {/* Mode toggle */}
+            <div className="tabs tabs-boxed tabs-xs">
+              <button
+                className={`tab tab-xs ${mode === 'single' ? 'tab-active' : ''}`}
+                onClick={() => setMode('single')}
+              >
+                This day
+              </button>
+              <button
+                className={`tab tab-xs ${mode === 'range' ? 'tab-active' : ''}`}
+                onClick={() => setMode('range')}
+              >
+                Date range
+              </button>
+            </div>
+
+            {mode === 'range' && (
+              <div>
+                <label className="label-text text-xs text-base-content/50 mb-1 block">End date</label>
+                <input
+                  type="date"
+                  className="input input-bordered input-xs w-full"
+                  value={endDate}
+                  min={date}
+                  onChange={(e) => setEndDate(e.target.value)}
+                />
+              </div>
+            )}
+
+            <ReasonAndNotesForm
+              reason={reason}
+              setReason={setReason}
+              notes={notes}
+              setNotes={setNotes}
+            />
+
+            <div className="flex justify-end gap-1">
+              <button className="btn btn-ghost btn-xs" onClick={onClose}>Cancel</button>
+              <button
+                className="btn btn-primary btn-xs"
+                onClick={mode === 'single' ? handleSaveSingle : handleSaveRange}
+                disabled={saving}
+              >
+                {saving ? <span className="loading loading-spinner loading-xs" /> : (
+                  mode === 'single' ? 'Mark day off' : 'Mark range'
+                )}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ReasonAndNotesForm({ reason, setReason, notes, setNotes }) {
+  return (
+    <>
+      <div>
+        <label className="label-text text-xs text-base-content/50 mb-1 block">Reason</label>
+        <select
+          className="select select-bordered select-xs w-full"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+        >
+          {REASONS.map(r => (
+            <option key={r.value} value={r.value}>{r.label}</option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="label-text text-xs text-base-content/50 mb-1 block">Notes (optional)</label>
+        <input
+          type="text"
+          className="input input-bordered input-xs w-full"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          placeholder='e.g. "Spring Break"'
+        />
+      </div>
+    </>
+  )
+}

--- a/src/hooks/useSchoolDays.js
+++ b/src/hooks/useSchoolDays.js
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+import { getSchoolDays } from '@/api/calendar'
+
+export function useSchoolDays(orgId, startDate, endDate) {
+  return useQuery({
+    queryKey: ['school-days', orgId, startDate, endDate],
+    queryFn: () => getSchoolDays(orgId, startDate, endDate),
+    enabled: !!orgId && !!startDate && !!endDate,
+  })
+}

--- a/src/lib/business-logic/rotation.js
+++ b/src/lib/business-logic/rotation.js
@@ -1,11 +1,12 @@
 // Rotation day calculation logic.
-// Implements the algorithm from docs/business-logic/01-schedule-and-calendar.md
+// Per-reason advancement: planned holidays pause the rotation,
+// unscheduled cancellations (weather/emergency) advance it.
 
 /**
  * Calculate the rotation day for a given date based on org settings and school days.
  *
  * @param {Object} orgSettings - organization.settings JSON
- * @param {Object[]} schoolDaysInRange - school_days records from term start through target date
+ * @param {Object[]} schoolDaysInRange - school_days records from term start through (but not including) target date
  * @param {Object} targetSchoolDay - the school_days record for the target date (may have explicit override)
  * @returns {string|null} - rotation day name (e.g., 'A', 'B') or null if org doesn't use rotation
  */
@@ -18,17 +19,60 @@ export function calculateRotationDay(orgSettings, schoolDaysInRange, targetSchoo
   }
 
   const rotationNames = orgSettings.rotation_day_names || ['A', 'B']
-  const mode = orgSettings.rotation_mode || 'continue'
 
-  let countableDays
-  if (mode === 'continue') {
-    // Skip non-school days — rotation advances only on days school is in session
-    countableDays = schoolDaysInRange.filter(d => d.is_school_day)
-  } else {
-    // "repeat" mode — cancelled days repeat, rotation doesn't advance
-    countableDays = schoolDaysInRange
-  }
+  // Count days that advance the rotation:
+  // - School days (is_school_day = true) always count
+  // - Unscheduled cancellations (weather/emergency) also count (rotation advances)
+  // - Planned holidays do NOT count (rotation pauses)
+  const countableDays = schoolDaysInRange.filter(d =>
+    d.is_school_day ||
+    d.override_reason === 'weather' ||
+    d.override_reason === 'emergency'
+  )
 
   const index = countableDays.length % rotationNames.length
   return rotationNames[index]
+}
+
+/**
+ * Check if a school day is an unscheduled cancellation (weather or emergency).
+ */
+export function isUnscheduledCancellation(schoolDay) {
+  return !schoolDay.is_school_day &&
+    (schoolDay.override_reason === 'weather' || schoolDay.override_reason === 'emergency')
+}
+
+/**
+ * Recalculate rotation days for all school days in a range.
+ * Returns only the days whose rotation_day changed (for efficient batch update).
+ *
+ * @param {Object[]} schoolDays - all school_days in the term, sorted by date
+ * @param {Object} orgSettings - organization.settings JSON
+ * @returns {Object[]} - school_days records that need updating (rotation_day changed)
+ */
+export function recalculateRotationDays(schoolDays, orgSettings) {
+  if (!orgSettings?.uses_rotation_schedule) return []
+
+  const rotationNames = orgSettings.rotation_day_names || ['A', 'B']
+  const changed = []
+  let rotationIndex = 0
+
+  for (const day of schoolDays) {
+    if (!day.is_school_day && day.override_reason === 'planned_holiday') {
+      // Planned holidays don't advance — rotation_day should be null
+      if (day.rotation_day !== null) {
+        changed.push({ ...day, rotation_day: null })
+      }
+      continue
+    }
+
+    // School days and unscheduled cancellations get a rotation label
+    const expected = rotationNames[rotationIndex % rotationNames.length]
+    if (day.rotation_day !== expected) {
+      changed.push({ ...day, rotation_day: expected })
+    }
+    rotationIndex++
+  }
+
+  return changed
 }

--- a/src/lib/business-logic/schoolDayGeneration.js
+++ b/src/lib/business-logic/schoolDayGeneration.js
@@ -1,0 +1,73 @@
+// School day generation logic.
+// Generates school_days rows for weekdays within a term date range,
+// calculating rotation labels using the per-reason algorithm.
+
+import { isUnscheduledCancellation } from './rotation'
+
+/**
+ * Get all weekday dates (Mon-Fri) in a date range, inclusive.
+ * Returns ISO date strings (YYYY-MM-DD).
+ */
+export function getWeekdaysInRange(startDate, endDate) {
+  const dates = []
+  const current = new Date(startDate + 'T00:00:00')
+  const end = new Date(endDate + 'T00:00:00')
+
+  while (current <= end) {
+    const dow = current.getDay()
+    if (dow >= 1 && dow <= 5) {
+      dates.push(current.toISOString().slice(0, 10))
+    }
+    current.setDate(current.getDate() + 1)
+  }
+
+  return dates
+}
+
+/**
+ * Generate school_days rows for a term date range.
+ * Skips dates that already have existing rows. Calculates rotation labels
+ * using the per-reason algorithm (planned holidays pause, weather/emergency advance).
+ *
+ * @param {string} orgId - organization ID
+ * @param {string} startDate - term start date (YYYY-MM-DD)
+ * @param {string} endDate - term end date (YYYY-MM-DD)
+ * @param {Object} orgSettings - organization.settings JSON
+ * @param {Object[]} existingSchoolDays - existing school_days in this range (sorted by date)
+ * @returns {Object[]} - new school_days rows to upsert
+ */
+export function generateSchoolDays(orgId, startDate, endDate, orgSettings, existingSchoolDays = []) {
+  const weekdays = getWeekdaysInRange(startDate, endDate)
+  const existingByDate = new Map(existingSchoolDays.map(d => [d.date, d]))
+  const rotationNames = orgSettings?.rotation_day_names || ['A', 'B']
+  const usesRotation = orgSettings?.uses_rotation_schedule ?? false
+
+  const newDays = []
+  let rotationIndex = 0
+
+  for (const date of weekdays) {
+    if (existingByDate.has(date)) {
+      // Day already exists — count it for rotation but don't overwrite
+      const existing = existingByDate.get(date)
+      if (existing.is_school_day || isUnscheduledCancellation(existing)) {
+        rotationIndex++
+      }
+      continue
+    }
+
+    const rotationDay = usesRotation
+      ? rotationNames[rotationIndex % rotationNames.length]
+      : null
+
+    newDays.push({
+      organization_id: orgId,
+      date,
+      is_school_day: true,
+      rotation_day: rotationDay,
+    })
+
+    rotationIndex++
+  }
+
+  return newDays
+}

--- a/src/pages/admin/OrgSettings.jsx
+++ b/src/pages/admin/OrgSettings.jsx
@@ -8,7 +8,25 @@ import { useTerms } from '@/hooks/useTerms'
 import { updateOrgSettings } from '@/api/organizations'
 import { upsertDefaultTemplate } from '@/api/scheduleTemplates'
 import { createTerm, updateTerm, deleteTerm, setCurrentTerm } from '@/api/terms'
+import { getSchoolDays, bulkUpsertSchoolDays, deleteSchoolDaysInRange } from '@/api/calendar'
 import { getBlocks } from '@/lib/constants'
+import { generateSchoolDays } from '@/lib/business-logic/schoolDayGeneration'
+import { recalculateRotationDays } from '@/lib/business-logic/rotation'
+import CalendarGrid from '@/components/calendar/CalendarGrid'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function dayBefore(dateStr) {
+  const d = new Date(dateStr + 'T00:00:00')
+  d.setDate(d.getDate() - 1)
+  return d.toISOString().slice(0, 10)
+}
+
+function dayAfter(dateStr) {
+  const d = new Date(dateStr + 'T00:00:00')
+  d.setDate(d.getDate() + 1)
+  return d.toISOString().slice(0, 10)
+}
 
 // ─── Block Schedule Section ──────────────────────────────────────────────────
 
@@ -243,7 +261,7 @@ function BlockScheduleSection({ orgSettings, defaultTemplate, orgId }) {
 
 // ─── Academic Terms Section ──────────────────────────────────────────────────
 
-function AcademicTermsSection({ terms, orgId }) {
+function AcademicTermsSection({ terms, orgId, orgSettings }) {
   const queryClient = useQueryClient()
   const [adding, setAdding] = useState(false)
   const [editingId, setEditingId] = useState(null)
@@ -312,9 +330,17 @@ function AcademicTermsSection({ terms, orgId }) {
       if (formCurrent) {
         await setCurrentTerm(orgId, newTerm.id)
       }
+
+      // Generate school days for the new term
+      const newDays = generateSchoolDays(orgId, formStart, formEnd, orgSettings)
+      if (newDays.length > 0) {
+        await bulkUpsertSchoolDays(newDays)
+      }
+
       queryClient.invalidateQueries({ queryKey: ['terms', orgId] })
+      queryClient.invalidateQueries({ queryKey: ['school-days', orgId] })
       resetForm()
-      showToast('success', 'Term created.')
+      showToast('success', `Term created. School days generated for ${formStart} – ${formEnd}.`)
     } catch (e) {
       showToast('error', e.message)
     } finally {
@@ -328,6 +354,7 @@ function AcademicTermsSection({ terms, orgId }) {
 
     setSaving(true)
     try {
+      const oldTerm = terms.find(t => t.id === editingId)
       await updateTerm(editingId, {
         name: formName.trim(),
         start_date: formStart,
@@ -336,9 +363,41 @@ function AcademicTermsSection({ terms, orgId }) {
       if (formCurrent) {
         await setCurrentTerm(orgId, editingId)
       }
+
+      // Handle school day generation/cleanup on date changes
+      let genMsg = ''
+      if (oldTerm && (oldTerm.start_date !== formStart || oldTerm.end_date !== formEnd)) {
+        // Delete days outside the new range
+        if (formStart > oldTerm.start_date) {
+          await deleteSchoolDaysInRange(orgId, oldTerm.start_date, formStart > formEnd ? formEnd : dayBefore(formStart))
+        }
+        if (formEnd < oldTerm.end_date) {
+          await deleteSchoolDaysInRange(orgId, dayAfter(formEnd), oldTerm.end_date)
+        }
+
+        // Fetch existing days in the new range and generate missing ones
+        const existing = await getSchoolDays(orgId, formStart, formEnd)
+        const newDays = generateSchoolDays(orgId, formStart, formEnd, orgSettings, existing)
+        if (newDays.length > 0) {
+          await bulkUpsertSchoolDays(newDays)
+        }
+
+        // Recalculate rotation for the full term
+        const allDays = await getSchoolDays(orgId, formStart, formEnd)
+        const rotationUpdates = recalculateRotationDays(allDays, orgSettings)
+        if (rotationUpdates.length > 0) {
+          await bulkUpsertSchoolDays(rotationUpdates)
+        }
+
+        genMsg = newDays.length > 0
+          ? ` Added ${newDays.length} school days.`
+          : ' Rotation recalculated.'
+      }
+
       queryClient.invalidateQueries({ queryKey: ['terms', orgId] })
+      queryClient.invalidateQueries({ queryKey: ['school-days', orgId] })
       resetForm()
-      showToast('success', 'Term updated.')
+      showToast('success', `Term updated.${genMsg}`)
     } catch (e) {
       showToast('error', e.message)
     } finally {
@@ -349,11 +408,16 @@ function AcademicTermsSection({ terms, orgId }) {
   async function handleDelete(termId) {
     setSaving(true)
     try {
+      const term = terms.find(t => t.id === termId)
+      if (term) {
+        await deleteSchoolDaysInRange(orgId, term.start_date, term.end_date)
+      }
       await deleteTerm(termId)
       queryClient.invalidateQueries({ queryKey: ['terms', orgId] })
+      queryClient.invalidateQueries({ queryKey: ['school-days', orgId] })
       resetForm()
       setConfirmDelete(null)
-      showToast('success', 'Term deleted.')
+      showToast('success', 'Term and associated school days deleted.')
     } catch (e) {
       showToast('error', e.message)
     } finally {
@@ -447,7 +511,7 @@ function AcademicTermsSection({ terms, orgId }) {
         {/* Delete confirmation */}
         {confirmDelete && (
           <div className="alert alert-warning mt-3 py-2">
-            <span className="text-sm">Delete this term? Activities referencing it will keep their dates but lose the term association.</span>
+            <span className="text-sm">Delete this term? All school day data (including holidays and cancellations) for this term will be removed.</span>
             <div className="flex gap-1">
               <button className="btn btn-ghost btn-xs" onClick={() => setConfirmDelete(null)}>Cancel</button>
               <button className="btn btn-error btn-xs" onClick={() => handleDelete(confirmDelete)} disabled={saving}>Delete</button>
@@ -533,14 +597,12 @@ function RotationDaysSection({ orgSettings, orgId }) {
 
   const [usesRotation, setUsesRotation] = useState(orgSettings?.uses_rotation_schedule ?? false)
   const [dayNames, setDayNames] = useState(orgSettings?.rotation_day_names ?? ['A', 'B'])
-  const [rotationMode, setRotationMode] = useState(orgSettings?.rotation_mode ?? 'continue')
 
   // Sync from server
   useEffect(() => {
     setUsesRotation(orgSettings?.uses_rotation_schedule ?? false)
     setDayNames(orgSettings?.rotation_day_names ?? ['A', 'B'])
-    setRotationMode(orgSettings?.rotation_mode ?? 'continue')
-  }, [orgSettings?.uses_rotation_schedule, orgSettings?.rotation_day_names, orgSettings?.rotation_mode])
+  }, [orgSettings?.uses_rotation_schedule, orgSettings?.rotation_day_names])
 
   function handleDayNameChange(idx, value) {
     setDayNames((prev) => {
@@ -565,7 +627,6 @@ function RotationDaysSection({ orgSettings, orgId }) {
       await updateOrgSettings(orgId, {
         uses_rotation_schedule: usesRotation,
         rotation_day_names: dayNames.map((n) => n.trim() || `Day ${dayNames.indexOf(n) + 1}`),
-        rotation_mode: rotationMode,
       })
       queryClient.invalidateQueries({ queryKey: ['org-settings', orgId] })
       setToast({ type: 'success', message: 'Rotation settings saved.' })
@@ -641,39 +702,9 @@ function RotationDaysSection({ orgSettings, orgId }) {
               <p className="text-xs text-base-content/40 mt-2">
                 Rotation day names identify alternating schedule days. Common examples: A Day / B Day, Gold / Maroon.
               </p>
-            </div>
-
-            {/* Cancellation mode */}
-            <div>
-              <label className="label-text text-sm font-medium mb-2 block">On cancellation</label>
-              <div className="space-y-2">
-                <label className="label cursor-pointer justify-start gap-3">
-                  <input
-                    type="radio"
-                    className="radio radio-sm"
-                    name="rotation_mode"
-                    checked={rotationMode === 'continue'}
-                    onChange={() => setRotationMode('continue')}
-                  />
-                  <div>
-                    <span className="label-text font-medium">Continue</span>
-                    <p className="text-xs text-base-content/50">Skip cancelled days in the rotation (Snow day on A → next day is B)</p>
-                  </div>
-                </label>
-                <label className="label cursor-pointer justify-start gap-3">
-                  <input
-                    type="radio"
-                    className="radio radio-sm"
-                    name="rotation_mode"
-                    checked={rotationMode === 'repeat'}
-                    onChange={() => setRotationMode('repeat')}
-                  />
-                  <div>
-                    <span className="label-text font-medium">Repeat</span>
-                    <p className="text-xs text-base-content/50">Repeat cancelled days (Snow day on A → next day is also A)</p>
-                  </div>
-                </label>
-              </div>
+              <p className="text-xs text-base-content/40 mt-1">
+                Planned holidays pause the rotation; unscheduled cancellations (weather, emergency) advance it.
+              </p>
             </div>
           </div>
         )}
@@ -709,10 +740,18 @@ export default function OrgSettings() {
         </p>
       </div>
 
-      <div className="space-y-6 max-w-3xl">
-        <BlockScheduleSection orgSettings={orgSettings} defaultTemplate={defaultTemplate} orgId={orgId} />
-        <AcademicTermsSection terms={terms} orgId={orgId} />
-        <RotationDaysSection orgSettings={orgSettings} orgId={orgId} />
+      <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)] gap-6">
+        {/* Left column: settings cards */}
+        <div className="space-y-6">
+          <BlockScheduleSection orgSettings={orgSettings} defaultTemplate={defaultTemplate} orgId={orgId} />
+          <AcademicTermsSection terms={terms} orgId={orgId} orgSettings={orgSettings} />
+          <RotationDaysSection orgSettings={orgSettings} orgId={orgId} />
+        </div>
+
+        {/* Right column: calendar */}
+        <div className="lg:sticky lg:top-4 lg:self-start">
+          <CalendarGrid orgId={orgId} orgSettings={orgSettings} terms={terms} />
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- **Two-column settings layout**: OrgSettings page restructured to responsive 2-column grid — settings cards on left, calendar pinned on right. Calendar reacts live to term/rotation changes.
- **CalendarGrid component**: Weekdays-only month grid with rotation labels (color-coded by day name), exception color coding (holiday=gray, weather=amber, emergency=red), today indicator, month navigation, and legend.
- **DayPopover component**: Click any day to open a compact popover for marking single-day exceptions or date ranges. Supports reason selection (planned holiday, weather, emergency), optional notes, and restoring school days.
- **School day auto-generation**: Saving a term generates `school_days` rows for all weekdays in the range with rotation labels. Term date edits extend/shrink school days accordingly. Term deletion cleans up associated school days.
- **Per-reason rotation algorithm**: Replaced global `rotation_mode` toggle with per-reason logic — planned holidays pause the rotation, weather/emergency cancellations advance it. Removed "On cancellation" radio buttons from Rotation Days settings.
- **Rotation recalculation**: After any exception mutation (add/remove/change), rotation labels are recalculated for the entire term and batch-updated.
- **API cleanup**: Removed duplicate term CRUD functions from `calendar.js` (canonical versions live in `terms.js`). Added `deleteSchoolDaysInRange()` to `calendar.js`.
- **Docs updated**: Rotation algorithm docs and schema docs updated to reflect per-reason logic and `rotation_mode` deprecation.

### New files
| File | Purpose |
|------|---------|
| `src/components/calendar/CalendarGrid.jsx` | Month grid with day cells, navigation, color coding, exception handlers |
| `src/components/calendar/DayPopover.jsx` | Day-click popover for single/range exception management |
| `src/hooks/useSchoolDays.js` | TanStack Query hook for fetching school days by date range |
| `src/lib/business-logic/schoolDayGeneration.js` | Weekday enumeration + rotation calculation for new school days |

### Modified files
| File | Changes |
|------|---------|
| `src/pages/admin/OrgSettings.jsx` | Two-column layout, CalendarGrid integration, generation on term save, rotation_mode removal |
| `src/lib/business-logic/rotation.js` | Per-reason algorithm + `recalculateRotationDays()` utility |
| `src/api/calendar.js` | Removed duplicate term functions, added `deleteSchoolDaysInRange()` |
| `docs/business-logic/01-schedule-and-calendar.md` | Updated rotation algorithm docs |
| `docs/schema/01-core-tables.md` | Noted `rotation_mode` deprecation |

## Test plan

- [x] Navigate to `/admin/settings` — verify two-column layout renders (settings left, calendar right)
- [x] On small screens, verify calendar stacks below settings (responsive)
- [x] Create a new term — verify school days appear on the calendar with rotation labels
- [x] Edit a term's end date (extend) — verify new school days are generated
- [x] Edit a term's end date (shrink) — verify school days beyond new end are removed
- [x] Delete a term — verify school days are cleaned up
- [x] Click a school day on calendar — verify popover appears with "Mark day off" options
- [x] Mark a day as planned holiday — verify rotation pauses (subsequent labels shift)
- [x] Mark a day as weather cancellation — verify rotation advances (no shift)
- [x] Mark a date range as holiday (e.g., Spring Break) — verify all weekdays in range are marked
- [x] Restore a day off back to school day — verify rotation recalculates
- [x] Verify Rotation Days section no longer shows "On cancellation" radio buttons
- [x] Navigate calendar months — verify data loads per month and caches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1 