### PR TITLE
feat: teacher agenda dashboard with roster modal

### DIFF
--- a/src/api/agenda.js
+++ b/src/api/agenda.js
@@ -1,5 +1,5 @@
 import { supabase } from './supabase'
-import { upsertActivityInstance } from './instances'
+import { upsertActivityInstance, getInstancesForDate } from './instances'
 
 // Fetch display name info for a profile via SECURITY DEFINER function.
 // Bypasses RLS to avoid recursion when students need teacher names.
@@ -79,4 +79,94 @@ export async function ensureActivityInstances(activityIds, orgId, date) {
   await Promise.all(
     activityIds.map((id) => upsertActivityInstance(id, orgId, date))
   )
+}
+
+// Fetch all activities assigned to a teacher (as teacher_id or monitor_id),
+// plus active enrollment counts per activity. Does NOT filter by date —
+// date filtering happens client-side via activityMeetsToday.
+export async function getTeacherActivitiesForDate(teacherId, orgId) {
+  const { data, error } = await supabase
+    .from('activities')
+    .select('*')
+    .eq('is_active', true)
+    .eq('organization_id', orgId)
+    .or(`teacher_id.eq.${teacherId},monitor_id.eq.${teacherId}`)
+
+  if (error) throw error
+
+  // Fetch enrollment counts for these activities
+  const activityIds = data.map((a) => a.id)
+  if (activityIds.length === 0) {
+    return { activities: data, enrollmentCounts: new Map() }
+  }
+
+  const { data: enrollments, error: enrollError } = await supabase
+    .from('enrollments')
+    .select('activity_id')
+    .in('activity_id', activityIds)
+    .eq('is_active', true)
+
+  if (enrollError) throw enrollError
+
+  const countMap = new Map()
+  for (const e of enrollments) {
+    countMap.set(e.activity_id, (countMap.get(e.activity_id) ?? 0) + 1)
+  }
+
+  return { activities: data, enrollmentCounts: countMap }
+}
+
+// Fetch enrollment rosters for one or more activities with student profiles.
+export async function getRosterForActivities(activityIds) {
+  const { data, error } = await supabase
+    .from('enrollments')
+    .select('*, student:student_id(id, first_name, last_name, preferred_name)')
+    .in('activity_id', activityIds)
+    .eq('is_active', true)
+
+  if (error) throw error
+  return data
+}
+
+// Fetch existing attendance records for given activity instance IDs.
+export async function getAttendanceForInstances(instanceIds) {
+  if (instanceIds.length === 0) return []
+
+  const { data, error } = await supabase
+    .from('attendance_records')
+    .select('*')
+    .in('activity_instance_id', instanceIds)
+
+  if (error) throw error
+  return data
+}
+
+// Create or update a single attendance record.
+export async function upsertAttendanceRecord(instanceId, studentId, status, markedById) {
+  const { data, error } = await supabase
+    .from('attendance_records')
+    .upsert(
+      {
+        activity_instance_id: instanceId,
+        student_id: studentId,
+        status,
+        marked_by_id: markedById,
+        marked_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'activity_instance_id,student_id' }
+    )
+    .select()
+    .single()
+
+  if (error) throw error
+  return data
+}
+
+// Fetch activity instances for a date, filtered to specific activity IDs.
+// Used by roster modal to get instance IDs for attendance upserts.
+export async function getInstancesForActivities(orgId, date, activityIds) {
+  const instances = await getInstancesForDate(orgId, date)
+  const filtered = instances.filter((i) => activityIds.includes(i.activity_id))
+  return new Map(filtered.map((i) => [i.activity_id, i.id]))
 }

--- a/src/components/agenda/TeacherActivityCard.jsx
+++ b/src/components/agenda/TeacherActivityCard.jsx
@@ -1,0 +1,92 @@
+import { FaLayerGroup } from 'react-icons/fa6'
+import { getBlockLabel } from '@/lib/constants'
+
+function TeacherActivityCard({ item, blockLabels, onClick }) {
+  if (item.isAggregate) {
+    return (
+      <AggregateCard
+        item={item}
+        blockLabels={blockLabels}
+        onClick={onClick}
+      />
+    )
+  }
+
+  return <SingleCard item={item} blockLabels={blockLabels} onClick={onClick} />
+}
+
+function SingleCard({ item, blockLabels, onClick }) {
+  const timeRange = formatTimeRange(
+    item.default_start_time,
+    item.default_end_time
+  )
+  const blockLabel =
+    item.block != null ? getBlockLabel(item.block, blockLabels) : null
+  const metaParts = [timeRange, blockLabel, item.location].filter(Boolean)
+  const metaLine = metaParts.join(' \u00b7 ')
+
+  const count = item.enrollmentCount ?? 0
+  const countLabel = `${count} student${count !== 1 ? 's' : ''}`
+
+  return (
+    <div
+      className="bg-base-100 border border-base-300 rounded-lg shadow-sm overflow-hidden cursor-pointer hover:shadow-md transition-shadow h-full"
+      onClick={onClick}
+    >
+      <div className="p-3 flex flex-col gap-0.5">
+        <div className="font-medium truncate">{item.name}</div>
+        {metaLine && (
+          <div className="text-sm text-base-content/60 truncate">
+            {metaLine}
+          </div>
+        )}
+        <div className="text-sm text-base-content/50">{countLabel}</div>
+      </div>
+    </div>
+  )
+}
+
+function AggregateCard({ item, blockLabels, onClick }) {
+  const timeRange = formatTimeRange(
+    item.default_start_time,
+    item.default_end_time
+  )
+  const blockLabel =
+    item.block != null ? getBlockLabel(item.block, blockLabels) : 'Unassigned'
+
+  const countLabel = `${item.activityCount} activities \u00b7 ${item.totalEnrollment} students`
+
+  return (
+    <div
+      className="bg-base-200 border border-base-300 rounded-lg shadow-sm overflow-hidden cursor-pointer hover:shadow-md transition-shadow h-full"
+      onClick={onClick}
+    >
+      <div className="p-3 flex flex-col gap-0.5">
+        <div className="font-medium flex items-center gap-1.5">
+          <FaLayerGroup size={14} />
+          <span className="truncate">{blockLabel}</span>
+        </div>
+        {timeRange && (
+          <div className="text-sm text-base-content/60">{timeRange}</div>
+        )}
+        <div className="text-sm text-base-content/50">{countLabel}</div>
+      </div>
+    </div>
+  )
+}
+
+function formatTimeRange(startTime, endTime) {
+  if (!startTime || !endTime) return null
+  return `${formatTime(startTime)} \u2013 ${formatTime(endTime)}`
+}
+
+function formatTime(timeStr) {
+  const [h, m] = timeStr.split(':').map(Number)
+  const suffix = h >= 12 ? 'p' : 'a'
+  const hour12 = h === 0 ? 12 : h > 12 ? h - 12 : h
+  return m === 0
+    ? `${hour12}${suffix}`
+    : `${hour12}:${String(m).padStart(2, '0')}${suffix}`
+}
+
+export default TeacherActivityCard

--- a/src/components/roster/RosterModal.jsx
+++ b/src/components/roster/RosterModal.jsx
@@ -1,0 +1,279 @@
+import { useState, useCallback } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { FaLayerGroup } from 'react-icons/fa6'
+import { useRoster } from '@/hooks/useRoster'
+import { upsertAttendanceRecord } from '@/api/agenda'
+import { getBlockLabel } from '@/lib/constants'
+import { formatDateISO } from '@/lib/scheduleUtils'
+
+const STATUS_OPTIONS = [
+  { key: 'present', label: 'P', fullLabel: 'Present', btnClass: 'btn-success' },
+  { key: 'absent', label: 'A', fullLabel: 'Absent', btnClass: 'btn-error' },
+  { key: 'excused', label: 'E', fullLabel: 'Excused', btnClass: 'btn-warning' },
+  { key: 'tardy', label: 'T', fullLabel: 'Tardy', btnClass: 'btn-info' },
+]
+
+function RosterModal({
+  activities,
+  isAggregate,
+  date,
+  orgId,
+  teacherId,
+  blockLabels,
+  onClose,
+}) {
+  const activityIds = activities.map((a) => a.id)
+  const { students, attendanceByStudent, instances, isLoading, error } =
+    useRoster(activityIds, date, orgId, activities)
+
+  const [pendingChanges, setPendingChanges] = useState(new Map())
+  const [saving, setSaving] = useState(false)
+  const queryClient = useQueryClient()
+
+  const getStudentStatus = useCallback(
+    (studentId) => {
+      return (
+        pendingChanges.get(studentId) ??
+        attendanceByStudent.get(studentId)?.status ??
+        null
+      )
+    },
+    [pendingChanges, attendanceByStudent]
+  )
+
+  function toggleAttendance(studentId, status) {
+    setPendingChanges((prev) => {
+      const next = new Map(prev)
+      const initial = attendanceByStudent.get(studentId)?.status ?? null
+      if (status === initial) {
+        next.delete(studentId)
+      } else {
+        next.set(studentId, status)
+      }
+      return next
+    })
+  }
+
+  async function handleSave() {
+    setSaving(true)
+    try {
+      const upserts = []
+      for (const [studentId, status] of pendingChanges) {
+        // Find the activity this student belongs to
+        const student = students.find((s) => s.studentId === studentId)
+        if (!student) continue
+        const instanceId = instances.get(student.activityId)
+        if (!instanceId) continue
+
+        upserts.push(
+          upsertAttendanceRecord(instanceId, studentId, status, teacherId)
+        )
+      }
+      await Promise.all(upserts)
+
+      // Invalidate queries
+      const dateStr = formatDateISO(date)
+      queryClient.invalidateQueries({ queryKey: ['roster'] })
+      queryClient.invalidateQueries({
+        queryKey: ['teacher-agenda', teacherId, dateStr],
+      })
+
+      onClose()
+    } catch (err) {
+      console.error('Failed to save attendance:', err)
+      setSaving(false)
+    }
+  }
+
+  // Header content
+  const headerContent = buildHeader(activities, isAggregate, blockLabels)
+
+  return (
+    <dialog className="modal modal-open">
+      <div className="modal-box max-w-2xl">
+        {/* Header */}
+        <button
+          className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
+          onClick={onClose}
+        >
+          ✕
+        </button>
+        <div className="mb-4">
+          <h3 className="font-bold text-lg flex items-center gap-1.5">
+            {headerContent.icon}
+            {headerContent.title}
+          </h3>
+          <p className="text-sm text-base-content/60">{headerContent.subtitle}</p>
+          <p className="text-sm text-base-content/50">{headerContent.count}</p>
+        </div>
+
+        <div className="divider my-0" />
+
+        {/* Body */}
+        <div className="py-4 max-h-[60vh] overflow-y-auto">
+          {isLoading && (
+            <div className="flex justify-center py-8">
+              <span className="loading loading-spinner loading-md" />
+            </div>
+          )}
+
+          {error && (
+            <div className="text-error text-center py-4">
+              Failed to load roster.
+            </div>
+          )}
+
+          {!isLoading && !error && students.length === 0 && (
+            <p className="text-base-content/50 text-center py-8">
+              No students enrolled.
+            </p>
+          )}
+
+          {!isLoading &&
+            !error &&
+            students.map((student) => (
+              <StudentRow
+                key={`${student.studentId}-${student.activityId}`}
+                student={student}
+                isAggregate={isAggregate}
+                currentStatus={getStudentStatus(student.studentId)}
+                onToggle={toggleAttendance}
+              />
+            ))}
+        </div>
+
+        {/* Footer */}
+        <div className="modal-action">
+          <button className="btn btn-ghost" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            className="btn btn-primary"
+            disabled={pendingChanges.size === 0 || saving}
+            onClick={handleSave}
+          >
+            {saving && <span className="loading loading-spinner loading-xs" />}
+            {pendingChanges.size > 0
+              ? `Save (${pendingChanges.size})`
+              : 'Save'}
+          </button>
+        </div>
+      </div>
+      <form method="dialog" className="modal-backdrop">
+        <button onClick={onClose}>close</button>
+      </form>
+    </dialog>
+  )
+}
+
+function StudentRow({ student, isAggregate, currentStatus, onToggle }) {
+  const displayName = student.preferredName
+    ? `${student.preferredName} ${student.lastName}`
+    : `${student.firstName} ${student.lastName}`
+
+  const activityLabel = student.activityLocation
+    ? `${student.activityName} \u00b7 ${student.activityLocation}`
+    : student.activityName
+
+  return (
+    <div className="flex items-center justify-between gap-2 py-2 px-1">
+      <div className="flex-1 min-w-0">
+        <span className="truncate block">{displayName}</span>
+        {isAggregate && (
+          <span className="text-sm text-base-content/50 italic truncate block">
+            {activityLabel}
+          </span>
+        )}
+      </div>
+
+      {student.requiresAttendance ? (
+        <div className="join shrink-0">
+          {STATUS_OPTIONS.map(({ key, label, fullLabel, btnClass }) => (
+            <button
+              key={key}
+              className={`btn btn-xs join-item ${
+                currentStatus === key ? btnClass : 'btn-ghost'
+              }`}
+              title={fullLabel}
+              onClick={() => onToggle(student.studentId, key)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      ) : (
+        <span className="text-sm text-base-content/40 shrink-0">
+          No attendance
+        </span>
+      )}
+    </div>
+  )
+}
+
+function buildHeader(activities, isAggregate, blockLabels) {
+  if (isAggregate) {
+    const block = activities[0]?.block
+    const blockLabel =
+      block != null ? getBlockLabel(block, blockLabels) : 'Unassigned'
+
+    const starts = activities.map((a) => a.default_start_time).filter(Boolean)
+    const ends = activities.map((a) => a.default_end_time).filter(Boolean)
+    const earliestStart = starts.length
+      ? starts.reduce((a, b) => (a < b ? a : b))
+      : null
+    const latestEnd = ends.length
+      ? ends.reduce((a, b) => (a > b ? a : b))
+      : null
+
+    const timeRange = formatTimeRange(earliestStart, latestEnd)
+    const subtitleParts = [timeRange, `${activities.length} activities`].filter(
+      Boolean
+    )
+
+    const totalStudents = activities.reduce(
+      (sum, a) => sum + (a.enrollmentCount ?? 0),
+      0
+    )
+
+    return {
+      icon: <FaLayerGroup size={16} />,
+      title: blockLabel,
+      subtitle: subtitleParts.join(' \u00b7 '),
+      count: `${totalStudents} students`,
+    }
+  }
+
+  const activity = activities[0]
+  const timeRange = formatTimeRange(
+    activity.default_start_time,
+    activity.default_end_time
+  )
+  const blockLabel =
+    activity.block != null
+      ? getBlockLabel(activity.block, blockLabels)
+      : null
+  const metaParts = [timeRange, blockLabel, activity.location].filter(Boolean)
+
+  return {
+    icon: null,
+    title: activity.name,
+    subtitle: metaParts.join(' \u00b7 '),
+    count: `${activity.enrollmentCount ?? 0} students`,
+  }
+}
+
+function formatTimeRange(startTime, endTime) {
+  if (!startTime || !endTime) return null
+  return `${formatTime(startTime)} \u2013 ${formatTime(endTime)}`
+}
+
+function formatTime(timeStr) {
+  const [h, m] = timeStr.split(':').map(Number)
+  const suffix = h >= 12 ? 'p' : 'a'
+  const hour12 = h === 0 ? 12 : h > 12 ? h - 12 : h
+  return m === 0
+    ? `${hour12}${suffix}`
+    : `${hour12}:${String(m).padStart(2, '0')}${suffix}`
+}
+
+export default RosterModal

--- a/src/hooks/useRoster.js
+++ b/src/hooks/useRoster.js
@@ -1,0 +1,70 @@
+import { useQuery } from '@tanstack/react-query'
+import {
+  getRosterForActivities,
+  getAttendanceForInstances,
+  getInstancesForActivities,
+} from '@/api/agenda'
+import { formatDateISO } from '@/lib/scheduleUtils'
+
+export function useRoster(activityIds, date, orgId, activities = []) {
+  const dateStr = formatDateISO(date)
+  const sortedKey = [...activityIds].sort().join(',')
+
+  const rosterQuery = useQuery({
+    queryKey: ['roster', sortedKey, dateStr],
+    queryFn: async () => {
+      // 1. Fetch enrollments with student profiles
+      const enrollments = await getRosterForActivities(activityIds)
+
+      // 2. Fetch instance IDs for these activities on this date
+      const instanceMap = await getInstancesForActivities(orgId, dateStr, activityIds)
+
+      // 3. Fetch existing attendance records for those instances
+      const instanceIds = [...instanceMap.values()]
+      const attendanceRecords = await getAttendanceForInstances(instanceIds)
+
+      // 4. Build attendance-by-student map
+      const attendanceByStudent = new Map()
+      for (const record of attendanceRecords) {
+        attendanceByStudent.set(record.student_id, {
+          status: record.status,
+          recordId: record.id,
+        })
+      }
+
+      // 5. Build activity lookup for names/locations/flags
+      const activityLookup = new Map()
+      for (const a of activities) {
+        activityLookup.set(a.id, a)
+      }
+
+      // 6. Flatten enrollments into student list
+      const students = enrollments
+        .map((e) => {
+          const activity = activityLookup.get(e.activity_id)
+          return {
+            studentId: e.student.id,
+            firstName: e.student.first_name,
+            lastName: e.student.last_name,
+            preferredName: e.student.preferred_name,
+            activityId: e.activity_id,
+            activityName: activity?.name ?? '',
+            activityLocation: activity?.location ?? null,
+            requiresAttendance: activity?.requires_attendance ?? true,
+          }
+        })
+        .sort((a, b) => a.lastName.localeCompare(b.lastName))
+
+      return { students, attendanceByStudent, instances: instanceMap }
+    },
+    enabled: activityIds.length > 0 && !!orgId,
+  })
+
+  return {
+    students: rosterQuery.data?.students ?? [],
+    attendanceByStudent: rosterQuery.data?.attendanceByStudent ?? new Map(),
+    instances: rosterQuery.data?.instances ?? new Map(),
+    isLoading: rosterQuery.isLoading,
+    error: rosterQuery.error,
+  }
+}

--- a/src/hooks/useTeacherAgenda.js
+++ b/src/hooks/useTeacherAgenda.js
@@ -1,0 +1,40 @@
+import { useQuery } from '@tanstack/react-query'
+import { getTeacherActivitiesForDate } from '@/api/agenda'
+import { getSchoolDays } from '@/api/calendar'
+import { activityMeetsToday, formatDateISO } from '@/lib/scheduleUtils'
+
+export function useTeacherAgenda(teacherId, date, orgId) {
+  const dateStr = formatDateISO(date)
+
+  const activitiesQuery = useQuery({
+    queryKey: ['teacher-agenda', teacherId, dateStr],
+    queryFn: () => getTeacherActivitiesForDate(teacherId, orgId),
+    enabled: !!teacherId && !!orgId,
+  })
+
+  const schoolDayQuery = useQuery({
+    queryKey: ['school-days', orgId, dateStr, dateStr],
+    queryFn: () => getSchoolDays(orgId, dateStr, dateStr),
+    enabled: !!orgId,
+  })
+
+  const allActivities = activitiesQuery.data?.activities ?? []
+  const enrollmentCounts = activitiesQuery.data?.enrollmentCounts ?? new Map()
+  const schoolDay = schoolDayQuery.data?.[0] ?? null
+
+  const activities = allActivities
+    .filter((a) => activityMeetsToday(a, date, schoolDay))
+    .sort((a, b) => {
+      if (!a.default_start_time || !b.default_start_time) return 0
+      return a.default_start_time.localeCompare(b.default_start_time)
+    })
+
+  return {
+    activities,
+    allActivities,
+    enrollmentCounts,
+    schoolDay,
+    isLoading: activitiesQuery.isLoading || schoolDayQuery.isLoading,
+    error: activitiesQuery.error || schoolDayQuery.error,
+  }
+}

--- a/src/pages/teacher/Dashboard.jsx
+++ b/src/pages/teacher/Dashboard.jsx
@@ -1,26 +1,270 @@
+import { useState, useEffect, useMemo } from 'react'
+import useAuthStore from '@/store/authStore'
+import { useTeacherAgenda } from '@/hooks/useTeacherAgenda'
+import { useOrgSettings } from '@/hooks/useOrgSettings'
+import { useDefaultScheduleTemplate } from '@/hooks/useScheduleTemplate'
+import { ensureActivityInstances } from '@/api/agenda'
+import { formatDateISO, addDays, subDays, isSameDay } from '@/lib/scheduleUtils'
+import SingleDayAgenda from '@/components/agenda/SingleDayAgenda'
+import TeacherActivityCard from '@/components/agenda/TeacherActivityCard'
+import RosterModal from '@/components/roster/RosterModal'
+import {
+  timeToMinutes,
+  floorToHour,
+  ceilToHour,
+  DEFAULT_GRID_START,
+  DEFAULT_GRID_END,
+} from '@/components/agenda/agendaUtils'
+
 function Dashboard() {
-  return (
-    <div>
-      <h1 className="text-3xl font-bold mb-2">My Activities</h1>
-      <p className="text-base-content/60 mb-6">Activity rosters coming soon</p>
+  const [date, setDate] = useState(new Date())
+  const [rosterTarget, setRosterTarget] = useState(null)
+  const profile = useAuthStore((s) => s.profile)
+  const orgId = profile?.organization_id
+  const teacherId = profile?.id
 
-      <div className="grid grid-cols-1 gap-4">
-        <div className="card bg-base-100 shadow-xl">
-          <div className="card-body">
-            <h2 className="card-title">Current Block</h2>
-            <p className="text-base-content/60">Active roster will appear here</p>
-          </div>
-        </div>
+  // Data hooks
+  const { activities, allActivities, enrollmentCounts, schoolDay, isLoading, error } =
+    useTeacherAgenda(teacherId, date, orgId)
+  const { data: orgSettings } = useOrgSettings(orgId)
+  const { data: template } = useDefaultScheduleTemplate(orgId)
 
-        <div className="card bg-base-100 shadow-xl">
-          <div className="card-body">
-            <h2 className="card-title">Today's Activities</h2>
-            <p className="text-base-content/60">Your full daily schedule will appear here</p>
-          </div>
-        </div>
+  // Instance upsert (fire-and-forget)
+  useEffect(() => {
+    if (activities.length > 0 && orgId) {
+      ensureActivityInstances(
+        activities.map((a) => a.id),
+        orgId,
+        formatDateISO(date)
+      ).catch(console.error)
+    }
+  }, [activities, orgId, date])
+
+  // Date navigation
+  const goToPrev = () => setDate((d) => subDays(d, 1))
+  const goToNext = () => setDate((d) => addDays(d, 1))
+  const isToday = isSameDay(date, new Date())
+
+  // Rotation day display
+  const usesRotation =
+    allActivities?.some((a) => a.rotation_day_type != null) ?? false
+  const rotationLabel =
+    usesRotation && schoolDay?.rotation_day
+      ? schoolDay.rotation_day + ' Day'
+      : null
+
+  // Block overlay data
+  const blockDefinitions = useMemo(
+    () =>
+      (template?.block_definitions ?? []).filter(
+        (d) => d.start_time && d.end_time
+      ),
+    [template]
+  )
+  const blockLabels = orgSettings?.block_labels ?? []
+
+  // Block grouping with simplified two-tier density
+  const displayItems = useMemo(() => {
+    const blockGroups = groupByBlock(activities)
+    const items = []
+
+    for (const [blockKey, groupActivities] of blockGroups) {
+      if (groupActivities.length === 1) {
+        const activity = groupActivities[0]
+        items.push({
+          ...activity,
+          isAggregate: false,
+          enrollmentCount: enrollmentCounts.get(activity.id) ?? 0,
+        })
+      } else {
+        const starts = groupActivities
+          .map((a) => a.default_start_time)
+          .filter(Boolean)
+        const ends = groupActivities
+          .map((a) => a.default_end_time)
+          .filter(Boolean)
+        const earliestStart = starts.reduce((a, b) => (a < b ? a : b))
+        const latestEnd = ends.reduce((a, b) => (a > b ? a : b))
+        const totalEnrollment = groupActivities.reduce(
+          (sum, a) => sum + (enrollmentCounts.get(a.id) ?? 0),
+          0
+        )
+
+        items.push({
+          id: `agg-${blockKey}`,
+          isAggregate: true,
+          block: blockKey === 'null' ? null : Number(blockKey),
+          activities: groupActivities.map((a) => ({
+            ...a,
+            enrollmentCount: enrollmentCounts.get(a.id) ?? 0,
+          })),
+          activityCount: groupActivities.length,
+          totalEnrollment,
+          default_start_time: earliestStart,
+          default_end_time: latestEnd,
+        })
+      }
+    }
+
+    return items.sort((a, b) => {
+      if (!a.default_start_time || !b.default_start_time) return 0
+      return a.default_start_time.localeCompare(b.default_start_time)
+    })
+  }, [activities, enrollmentCounts])
+
+  // Grid bounds
+  const gridBounds = useMemo(() => {
+    if (displayItems.length === 0) {
+      return { start: DEFAULT_GRID_START, end: DEFAULT_GRID_END }
+    }
+    const starts = displayItems
+      .map((a) => a.default_start_time)
+      .filter(Boolean)
+    const ends = displayItems
+      .map((a) => a.default_end_time)
+      .filter(Boolean)
+    if (starts.length === 0) {
+      return { start: DEFAULT_GRID_START, end: DEFAULT_GRID_END }
+    }
+    const minStart = starts.reduce((a, b) => (a < b ? a : b))
+    const maxEnd = ends.reduce((a, b) => (a > b ? a : b))
+    return {
+      start:
+        minStart < DEFAULT_GRID_START
+          ? floorToHour(minStart)
+          : DEFAULT_GRID_START,
+      end:
+        maxEnd > DEFAULT_GRID_END ? ceilToHour(maxEnd) : DEFAULT_GRID_END,
+    }
+  }, [displayItems])
+
+  const gridStartMinutes = timeToMinutes(gridBounds.start)
+  const gridEndMinutes = timeToMinutes(gridBounds.end)
+
+  // Date header formatting
+  const fullDateLabel = isToday
+    ? `Today, ${date.toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}`
+    : date.toLocaleDateString('en-US', {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+      })
+
+  // Render card function
+  const renderCard = (item) => (
+    <TeacherActivityCard
+      item={item}
+      blockLabels={blockLabels}
+      onClick={() => handleCardClick(item)}
+    />
+  )
+
+  function handleCardClick(item) {
+    if (item.isAggregate) {
+      setRosterTarget({ activities: item.activities, isAggregate: true })
+    } else {
+      setRosterTarget({ activities: [item], isAggregate: false })
+    }
+  }
+
+  if (error) {
+    return (
+      <div className="text-error text-center py-8">
+        Failed to load schedule. Please try again.
       </div>
+    )
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      {/* Date navigation header */}
+      <div className="flex items-center justify-between mb-4">
+        <button className="btn btn-ghost btn-sm" onClick={goToPrev}>
+          &#8249;
+        </button>
+        <div className="text-center">
+          <h1 className="text-lg font-semibold">
+            {fullDateLabel}
+            {rotationLabel && (
+              <span className="text-base-content/60 font-normal">
+                {' \u2014 '}{rotationLabel}
+              </span>
+            )}
+          </h1>
+        </div>
+        <button className="btn btn-ghost btn-sm" onClick={goToNext}>
+          &#8250;
+        </button>
+      </div>
+
+      {/* Today shortcut when navigated away */}
+      {!isToday && (
+        <div className="text-center mb-3">
+          <button
+            className="btn btn-ghost btn-xs text-primary"
+            onClick={() => setDate(new Date())}
+          >
+            Back to today
+          </button>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {isLoading && (
+        <div className="flex justify-center py-16">
+          <span className="loading loading-spinner loading-md" />
+        </div>
+      )}
+
+      {/* Content */}
+      {!isLoading && displayItems.length > 0 && (
+        <SingleDayAgenda
+          activities={displayItems}
+          gridStartMinutes={gridStartMinutes}
+          gridEndMinutes={gridEndMinutes}
+          blockDefinitions={blockDefinitions}
+          blockLabels={blockLabels}
+          renderCard={renderCard}
+        />
+      )}
+
+      {/* Empty state */}
+      {!isLoading && displayItems.length === 0 && (
+        <div className="card bg-base-100 shadow-sm border border-base-300">
+          <div className="card-body items-center text-center py-16">
+            <p className="text-base-content/50">
+              No activities scheduled for this date.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Roster modal */}
+      {rosterTarget && (
+        <RosterModal
+          activities={rosterTarget.activities}
+          isAggregate={rosterTarget.isAggregate}
+          date={date}
+          orgId={orgId}
+          teacherId={teacherId}
+          blockLabels={blockLabels}
+          onClose={() => setRosterTarget(null)}
+        />
+      )}
     </div>
   )
+}
+
+// Simple group-by-block — activityMeetsToday has already filtered,
+// so no need to re-check days_of_week like groupActivitiesByBlock does.
+function groupByBlock(activities) {
+  const map = new Map()
+  for (const a of activities) {
+    const key = String(a.block ?? 'null')
+    if (!map.has(key)) map.set(key, [])
+    map.get(key).push(a)
+  }
+  return map
 }
 
 export default Dashboard


### PR DESCRIPTION
## Summary
- **Teacher Dashboard** replaces placeholder with full agenda view — date navigation, rotation day display, `SingleDayAgenda` integration with two-tier density model (single cards / aggregate cards at 2+ per block)
- **Roster Modal** opens on card click with P/A/E/T attendance buttons, local state change tracking, and batch save via `upsertAttendanceRecord`. Aggregate rosters show combined student list with activity labels. Non-attendance activities show read-only roster.
- **Data layer** adds `getTeacherActivitiesForDate`, `getRosterForActivities`, `getAttendanceForInstances`, `upsertAttendanceRecord` API functions plus `useTeacherAgenda` and `useRoster` hooks following established patterns

## New files
| File | Purpose |
|------|---------|
| `src/pages/teacher/Dashboard.jsx` | Page component with date nav, block grouping, agenda grid |
| `src/components/agenda/TeacherActivityCard.jsx` | Single + aggregate card rendering |
| `src/components/roster/RosterModal.jsx` | Attendance marking modal with local state + batch save |
| `src/hooks/useTeacherAgenda.js` | Teacher's assigned activities for a date |
| `src/hooks/useRoster.js` | Enrollment roster + attendance records for modal |

## Modified files
| File | Change |
|------|--------|
| `src/api/agenda.js` | 4 new API functions + `getInstancesForActivities` helper |

## Test plan
- [x] Log in as teacher → Dashboard shows today's activities in time-positioned cards
- [x] Navigate dates with `<` `>` arrows — activities filter correctly, "Back to today" link works
- [x] Rotation day label appears when teacher has rotation-dependent activities
- [x] Single-activity blocks show single card with name, time/block/location, enrollment count
- [x] Multi-activity blocks show aggregate card with layer icon, block label, activity count
- [x] Click single card → roster modal opens with student list and P/A/E/T buttons
- [x] Click aggregate card → combined roster with activity labels per student
- [x] Toggle attendance buttons — pending count updates in Save button
- [ ] Toggle back to original state → pending change removed
- [x] Save → attendance records upserted, modal closes
- [x] Re-open same roster → saved attendance state persists
- [x] Non-attendance activity card → modal opens in read-only mode, "No attendance" shown
- [x] Empty state on non-school days or dates with no activities
- [x] RLS: verify teacher can only see their own assigned activities

🤖 Generated with [Claude Code](https://claude.com/claude-code)