### PR TITLE
feat: teacher visibility of student actions in roster and cards

### DIFF
--- a/src/api/agenda.js
+++ b/src/api/agenda.js
@@ -171,6 +171,95 @@ export async function getInstancesForActivities(orgId, date, activityIds) {
   return new Map(filtered.map((i) => [i.activity_id, i.id]))
 }
 
+// --- Teacher action summary API functions ---
+
+// Fetch all presence waves for a set of activity instances (teacher view).
+export async function getWavesForInstances(instanceIds) {
+  if (instanceIds.length === 0) return []
+
+  const { data, error } = await supabase
+    .from('presence_waves')
+    .select('*')
+    .in('activity_instance_id', instanceIds)
+
+  if (error) throw error
+  return data
+}
+
+// Fetch all check-ins for a set of activity instances (teacher view).
+export async function getCheckInsForInstances(instanceIds) {
+  if (instanceIds.length === 0) return []
+
+  const { data, error } = await supabase
+    .from('check_ins')
+    .select('*')
+    .in('activity_instance_id', instanceIds)
+
+  if (error) throw error
+  return data
+}
+
+// Fetch all status updates for a set of activity instances (teacher view).
+export async function getStatusUpdatesForInstances(instanceIds) {
+  if (instanceIds.length === 0) return []
+
+  const { data, error } = await supabase
+    .from('status_updates')
+    .select('*')
+    .in('activity_instance_id', instanceIds)
+
+  if (error) throw error
+  return data
+}
+
+// Fetch full detail for a single student on a single activity instance.
+// Used by the student detail overlay.
+export async function getStudentInstanceDetail(studentId, instanceId) {
+  const [checkIns, waves, statusUpdates] = await Promise.all([
+    supabase
+      .from('check_ins')
+      .select('*')
+      .eq('student_id', studentId)
+      .eq('activity_instance_id', instanceId)
+      .maybeSingle()
+      .then(({ data, error }) => { if (error) throw error; return data }),
+    supabase
+      .from('presence_waves')
+      .select('*')
+      .eq('student_id', studentId)
+      .eq('activity_instance_id', instanceId)
+      .maybeSingle()
+      .then(({ data, error }) => { if (error) throw error; return data }),
+    supabase
+      .from('status_updates')
+      .select('*')
+      .eq('student_id', studentId)
+      .eq('activity_instance_id', instanceId)
+      .order('created_at', { ascending: true })
+      .then(({ data, error }) => { if (error) throw error; return data ?? [] }),
+  ])
+
+  // If check-in exists, fetch freeform tags
+  let freeformTags = []
+  if (checkIns?.id) {
+    const { data: tags, error: tagError } = await supabase
+      .from('checkin_activity_tags')
+      .select('*, activity:activity_id(name)')
+      .eq('checkin_id', checkIns.id)
+
+    if (!tagError && tags) {
+      freeformTags = tags.map(t => t.activity?.name).filter(Boolean)
+    }
+  }
+
+  return {
+    checkIn: checkIns,
+    wave: waves,
+    statusUpdates,
+    freeformTags,
+  }
+}
+
 // --- Student action API functions ---
 
 // Fetch existing check-ins for a student across multiple instances

--- a/src/components/agenda/TeacherActivityCard.jsx
+++ b/src/components/agenda/TeacherActivityCard.jsx
@@ -1,21 +1,30 @@
 import { FaLayerGroup } from 'react-icons/fa6'
+import { PiHandWaving } from 'react-icons/pi'
 import { getBlockLabel } from '@/lib/constants'
 
-function TeacherActivityCard({ item, blockLabels, onClick }) {
+function TeacherActivityCard({ item, blockLabels, waveCount = 0, onClick }) {
   if (item.isAggregate) {
     return (
       <AggregateCard
         item={item}
         blockLabels={blockLabels}
+        waveCount={waveCount}
         onClick={onClick}
       />
     )
   }
 
-  return <SingleCard item={item} blockLabels={blockLabels} onClick={onClick} />
+  return (
+    <SingleCard
+      item={item}
+      blockLabels={blockLabels}
+      waveCount={waveCount}
+      onClick={onClick}
+    />
+  )
 }
 
-function SingleCard({ item, blockLabels, onClick }) {
+function SingleCard({ item, blockLabels, waveCount, onClick }) {
   const timeRange = formatTimeRange(
     item.default_start_time,
     item.default_end_time
@@ -26,7 +35,6 @@ function SingleCard({ item, blockLabels, onClick }) {
   const metaLine = metaParts.join(' \u00b7 ')
 
   const count = item.enrollmentCount ?? 0
-  const countLabel = `${count} student${count !== 1 ? 's' : ''}`
 
   return (
     <div
@@ -35,26 +43,28 @@ function SingleCard({ item, blockLabels, onClick }) {
     >
       <div className="p-3 flex flex-col gap-0.5">
         <div className="font-medium truncate">{item.name}</div>
-        {metaLine && (
-          <div className="text-sm text-base-content/60 truncate">
-            {metaLine}
-          </div>
-        )}
-        <div className="text-sm text-base-content/50">{countLabel}</div>
+        <div className="text-sm text-base-content/60 truncate">
+          {metaLine && <>{metaLine} &middot; </>}
+          <span>{count}</span>
+          {waveCount > 0 && (
+            <span className="ml-1.5 inline-flex items-center gap-0.5">
+              <PiHandWaving size={14} className="inline" />
+              <span>{waveCount}</span>
+            </span>
+          )}
+        </div>
       </div>
     </div>
   )
 }
 
-function AggregateCard({ item, blockLabels, onClick }) {
+function AggregateCard({ item, blockLabels, waveCount, onClick }) {
   const timeRange = formatTimeRange(
     item.default_start_time,
     item.default_end_time
   )
   const blockLabel =
     item.block != null ? getBlockLabel(item.block, blockLabels) : 'Unassigned'
-
-  const countLabel = `${item.activityCount} activities \u00b7 ${item.totalEnrollment} students`
 
   return (
     <div
@@ -66,10 +76,17 @@ function AggregateCard({ item, blockLabels, onClick }) {
           <FaLayerGroup size={14} />
           <span className="truncate">{blockLabel}</span>
         </div>
-        {timeRange && (
-          <div className="text-sm text-base-content/60">{timeRange}</div>
-        )}
-        <div className="text-sm text-base-content/50">{countLabel}</div>
+        <div className="text-sm text-base-content/60 truncate">
+          {timeRange && <>{timeRange} &middot; </>}
+          <span>{item.activityCount} activities</span>
+          <span> &middot; {item.totalEnrollment}</span>
+          {waveCount > 0 && (
+            <span className="ml-1.5 inline-flex items-center gap-0.5">
+              <PiHandWaving size={14} className="inline" />
+              <span>{waveCount}</span>
+            </span>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/src/components/roster/RosterModal.jsx
+++ b/src/components/roster/RosterModal.jsx
@@ -1,10 +1,14 @@
 import { useState, useCallback } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { FaLayerGroup } from 'react-icons/fa6'
+import { PiHandWaving } from 'react-icons/pi'
+import { IoCheckmarkCircle, IoExitOutline } from 'react-icons/io5'
+import { MdLocationDisabled, MdOutlineAddComment } from 'react-icons/md'
 import { useRoster } from '@/hooks/useRoster'
 import { upsertAttendanceRecord } from '@/api/agenda'
 import { getBlockLabel } from '@/lib/constants'
 import { formatDateISO } from '@/lib/scheduleUtils'
+import StudentDetailOverlay from './StudentDetailOverlay'
 
 const STATUS_OPTIONS = [
   { key: 'present', label: 'P', fullLabel: 'Present', btnClass: 'btn-success' },
@@ -20,6 +24,7 @@ function RosterModal({
   orgId,
   teacherId,
   blockLabels,
+  actionSummary,
   onClose,
 }) {
   const activityIds = activities.map((a) => a.id)
@@ -28,6 +33,7 @@ function RosterModal({
 
   const [pendingChanges, setPendingChanges] = useState(new Map())
   const [saving, setSaving] = useState(false)
+  const [selectedStudent, setSelectedStudent] = useState(null)
   const queryClient = useQueryClient()
 
   const getStudentStatus = useCallback(
@@ -59,7 +65,6 @@ function RosterModal({
     try {
       const upserts = []
       for (const [studentId, status] of pendingChanges) {
-        // Find the activity this student belongs to
         const student = students.find((s) => s.studentId === studentId)
         if (!student) continue
         const instanceId = instances.get(student.activityId)
@@ -71,7 +76,6 @@ function RosterModal({
       }
       await Promise.all(upserts)
 
-      // Invalidate queries
       const dateStr = formatDateISO(date)
       queryClient.invalidateQueries({ queryKey: ['roster'] })
       queryClient.invalidateQueries({
@@ -83,6 +87,26 @@ function RosterModal({
       console.error('Failed to save attendance:', err)
       setSaving(false)
     }
+  }
+
+  function getActionData(student) {
+    if (!actionSummary) return { wave: null, checkIn: null, statusCount: 0 }
+    const key = `${student.studentId}-${student.activityId}`
+    return {
+      wave: actionSummary.waves?.get(key) ?? null,
+      checkIn: actionSummary.checkIns?.get(key) ?? null,
+      statusCount: actionSummary.statusCounts?.get(key) ?? 0,
+    }
+  }
+
+  function handleRowClick(student) {
+    const instanceId = actionSummary?.instances?.get(student.activityId) ?? instances.get(student.activityId)
+    const activity = activities.find((a) => a.id === student.activityId) ?? activities[0]
+    setSelectedStudent({
+      ...student,
+      instanceId,
+      activity,
+    })
   }
 
   // Header content
@@ -131,13 +155,16 @@ function RosterModal({
 
           {!isLoading &&
             !error &&
-            students.map((student) => (
+            students.map((student, index) => (
               <StudentRow
                 key={`${student.studentId}-${student.activityId}`}
                 student={student}
                 isAggregate={isAggregate}
                 currentStatus={getStudentStatus(student.studentId)}
                 onToggle={toggleAttendance}
+                actionData={getActionData(student)}
+                onClick={() => handleRowClick(student)}
+                isEven={index % 2 === 1}
               />
             ))}
         </div>
@@ -162,52 +189,140 @@ function RosterModal({
       <form method="dialog" className="modal-backdrop">
         <button onClick={onClose}>close</button>
       </form>
+
+      {/* Student detail overlay */}
+      {selectedStudent && (
+        <StudentDetailOverlay
+          isOpen={true}
+          onClose={() => setSelectedStudent(null)}
+          student={selectedStudent}
+          instanceId={selectedStudent.instanceId}
+          activity={selectedStudent.activity}
+          orgId={orgId}
+          blockLabels={blockLabels}
+        />
+      )}
     </dialog>
   )
 }
 
-function StudentRow({ student, isAggregate, currentStatus, onToggle }) {
+function StudentRow({
+  student,
+  isAggregate,
+  currentStatus,
+  onToggle,
+  actionData,
+  onClick,
+  isEven,
+}) {
   const displayName = student.preferredName
     ? `${student.preferredName} ${student.lastName}`
     : `${student.firstName} ${student.lastName}`
 
-  const activityLabel = student.activityLocation
-    ? `${student.activityName} \u00b7 ${student.activityLocation}`
-    : student.activityName
-
   return (
-    <div className="flex items-center justify-between gap-2 py-2 px-1">
-      <div className="flex-1 min-w-0">
-        <span className="truncate block">{displayName}</span>
-        {isAggregate && (
-          <span className="text-sm text-base-content/50 italic truncate block">
-            {activityLabel}
+    <div
+      className={`flex items-center gap-2 py-2.5 px-2 rounded-lg cursor-pointer hover:bg-base-200/50 transition-colors ${
+        isEven ? 'bg-base-200/30' : ''
+      }`}
+      onClick={onClick}
+    >
+      {/* Name */}
+      <div className="min-w-30 max-w-45 truncate font-medium">
+        {displayName}
+      </div>
+
+      {/* Activity label — aggregate only */}
+      {isAggregate && (
+        <div className="min-w-20 max-w-35 text-sm text-base-content/50 italic truncate">
+          {student.activityName}
+        </div>
+      )}
+
+      {/* Icon zone */}
+      <div className="flex-1 flex items-center gap-1.5 justify-end">
+        {actionData.wave && (
+          <span
+            className="text-success"
+            title={`Waved at ${formatTimestamp(actionData.wave.waved_at)}`}
+          >
+            <PiHandWaving size={16} />
+          </span>
+        )}
+        {actionData.checkIn && (
+          <CheckInIcon checkIn={actionData.checkIn} />
+        )}
+        {actionData.checkIn?.geofence_validated === false && (
+          <span className="text-error" title="Location check failed">
+            <MdLocationDisabled size={16} />
+          </span>
+        )}
+        {actionData.statusCount > 0 && (
+          <span
+            className="flex items-center gap-0.5 text-base-content/50"
+            title={`${actionData.statusCount} status update(s)`}
+          >
+            <MdOutlineAddComment size={14} />
+            <span className="text-xs">({actionData.statusCount})</span>
           </span>
         )}
       </div>
 
-      {student.requiresAttendance ? (
-        <div className="join shrink-0">
-          {STATUS_OPTIONS.map(({ key, label, fullLabel, btnClass }) => (
-            <button
-              key={key}
-              className={`btn btn-xs join-item ${
-                currentStatus === key ? btnClass : 'btn-ghost'
-              }`}
-              title={fullLabel}
-              onClick={() => onToggle(student.studentId, key)}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-      ) : (
-        <span className="text-sm text-base-content/40 shrink-0">
-          No attendance
-        </span>
-      )}
+      {/* PAET buttons — stop propagation */}
+      <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
+        {student.requiresAttendance ? (
+          <div className="flex items-center gap-1">
+            {STATUS_OPTIONS.map(({ key, label, fullLabel, btnClass }) => (
+              <button
+                key={key}
+                className={`btn btn-xs rounded ${
+                  currentStatus === key ? btnClass : 'btn-ghost'
+                }`}
+                title={fullLabel}
+                onClick={() => onToggle(student.studentId, key)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        ) : (
+          <span className="text-sm text-base-content/40 shrink-0">
+            No attendance
+          </span>
+        )}
+      </div>
     </div>
   )
+}
+
+function CheckInIcon({ checkIn }) {
+  if (checkIn.checked_out_at) {
+    return (
+      <span
+        className="text-success"
+        title={`Checked in ${formatTimestamp(checkIn.checked_in_at)}, out ${formatTimestamp(checkIn.checked_out_at)}`}
+      >
+        <IoExitOutline size={16} />
+      </span>
+    )
+  }
+  return (
+    <span
+      className="text-success"
+      title={`Checked in at ${formatTimestamp(checkIn.checked_in_at)}`}
+    >
+      <IoCheckmarkCircle size={16} />
+    </span>
+  )
+}
+
+function formatTimestamp(isoString) {
+  if (!isoString) return ''
+  const d = new Date(isoString)
+  return d.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  })
 }
 
 function buildHeader(activities, isAggregate, blockLabels) {

--- a/src/components/roster/StudentDetailOverlay.jsx
+++ b/src/components/roster/StudentDetailOverlay.jsx
@@ -1,0 +1,211 @@
+import { PiHandWaving } from 'react-icons/pi'
+import { IoCheckmarkCircle, IoExitOutline } from 'react-icons/io5'
+import { MdLocationDisabled } from 'react-icons/md'
+import { GiFlame } from 'react-icons/gi'
+import { useStudentInstanceDetail } from '@/hooks/useStudentInstanceDetail'
+import { getBlockLabel } from '@/lib/constants'
+
+const STATUS_TYPE_STYLES = {
+  plans: 'text-info',
+  progress: 'text-success',
+  reflection: 'text-base-content/70',
+}
+
+function StudentDetailOverlay({
+  isOpen,
+  onClose,
+  student,
+  instanceId,
+  activity,
+  orgId,
+  blockLabels,
+}) {
+  const { data: detail, isLoading } = useStudentInstanceDetail(
+    student?.studentId,
+    instanceId,
+    activity,
+    orgId
+  )
+
+  if (!isOpen || !student) return null
+
+  const displayName = student.preferredName
+    ? `${student.preferredName} ${student.lastName}`
+    : `${student.firstName} ${student.lastName}`
+
+  const activityName = activity?.name ?? student.activityName ?? ''
+  const blockLabel =
+    activity?.block != null
+      ? getBlockLabel(activity.block, blockLabels)
+      : null
+  const subtitle = [activityName, blockLabel].filter(Boolean).join(' \u00b7 ')
+
+  const hasData =
+    detail && (detail.checkIn || detail.wave || detail.statusUpdates?.length > 0)
+
+  return (
+    <dialog className="modal modal-open" style={{ zIndex: 60 }}>
+      <div className="modal-box max-w-md">
+        {/* Header */}
+        <button
+          className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
+          onClick={onClose}
+        >
+          ✕
+        </button>
+        <div className="mb-2">
+          <h3 className="font-bold text-lg">{displayName}</h3>
+          {subtitle && (
+            <p className="text-sm text-base-content/60">{subtitle}</p>
+          )}
+        </div>
+
+        <div className="divider my-0" />
+
+        {/* Body */}
+        <div className="py-4 space-y-5 max-h-[60vh] overflow-y-auto">
+          {isLoading && (
+            <div className="flex justify-center py-8">
+              <span className="loading loading-spinner loading-md" />
+            </div>
+          )}
+
+          {!isLoading && !hasData && (
+            <p className="text-base-content/50 text-center py-8">
+              No activity recorded for this date.
+            </p>
+          )}
+
+          {!isLoading && detail && (
+            <>
+              {/* Check-In Section */}
+              {detail.checkIn && (
+                <div>
+                  <SectionHeader>CHECK-IN</SectionHeader>
+                  <div className="space-y-1.5 mt-2">
+                    <div className="flex items-center gap-2 text-sm">
+                      <IoCheckmarkCircle size={16} className="text-success shrink-0" />
+                      <span>
+                        Checked in at{' '}
+                        {formatTimestamp(detail.checkIn.checked_in_at)}
+                      </span>
+                    </div>
+                    {detail.checkIn.checked_out_at && (
+                      <div className="flex items-center gap-2 text-sm">
+                        <IoExitOutline size={16} className="text-success shrink-0" />
+                        <span>
+                          Checked out at{' '}
+                          {formatTimestamp(detail.checkIn.checked_out_at)}
+                        </span>
+                      </div>
+                    )}
+                    {detail.checkIn.geofence_validated === false && (
+                      <div className="flex items-center gap-2 text-sm text-error">
+                        <MdLocationDisabled size={16} className="shrink-0" />
+                        <span>Location check failed</span>
+                      </div>
+                    )}
+                    {detail.freeformTags?.length > 0 && (
+                      <div className="text-sm text-base-content/70 mt-1">
+                        Working on: {detail.freeformTags.join(', ')}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {/* Wave Section */}
+              {detail.wave && (
+                <div>
+                  <SectionHeader>WAVE</SectionHeader>
+                  <div className="space-y-1.5 mt-2">
+                    <div className="flex items-center gap-2 text-sm">
+                      <PiHandWaving size={16} className="text-success shrink-0" />
+                      <span>
+                        Waved at {formatTimestamp(detail.wave.waved_at)}
+                      </span>
+                    </div>
+                    {detail.streak > 0 && (
+                      <div className="flex items-center gap-2 text-sm">
+                        <GiFlame
+                          size={16}
+                          className={`shrink-0 ${
+                            detail.streak >= 5
+                              ? 'text-amber-500'
+                              : 'text-base-content/40'
+                          }`}
+                        />
+                        <span>{detail.streak} day streak</span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {/* Status Updates Section */}
+              {detail.statusUpdates?.length > 0 && (
+                <div>
+                  <SectionHeader>STATUS UPDATES</SectionHeader>
+                  <div className="space-y-0 mt-2 border border-base-300 rounded-lg overflow-hidden">
+                    {detail.statusUpdates.map((update, i) => (
+                      <div
+                        key={update.id}
+                        className={`p-3 ${
+                          i > 0 ? 'border-t border-base-300' : ''
+                        }`}
+                      >
+                        <div className="flex items-center gap-2 mb-1">
+                          <span
+                            className={`text-xs font-medium ${
+                              STATUS_TYPE_STYLES[update.status_type] ?? ''
+                            }`}
+                          >
+                            {update.status_type}
+                          </span>
+                          <span className="text-xs text-base-content/40">
+                            {formatTimestamp(update.created_at)}
+                          </span>
+                        </div>
+                        <p className="text-sm">{update.content}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="modal-action">
+          <button className="btn btn-ghost" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+      <form method="dialog" className="modal-backdrop" style={{ zIndex: -1 }}>
+        <button onClick={onClose}>close</button>
+      </form>
+    </dialog>
+  )
+}
+
+function SectionHeader({ children }) {
+  return (
+    <h4 className="text-xs font-semibold tracking-wide text-base-content/40 uppercase">
+      {children}
+    </h4>
+  )
+}
+
+function formatTimestamp(isoString) {
+  if (!isoString) return ''
+  const d = new Date(isoString)
+  return d.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  })
+}
+
+export default StudentDetailOverlay

--- a/src/hooks/useStreakData.js
+++ b/src/hooks/useStreakData.js
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { getWaveHistory } from '@/api/agenda'
 import { getSchoolDays } from '@/api/calendar'
 import { formatDateISO, subDays } from '@/lib/scheduleUtils'
+import { calculateStreak } from '@/lib/streakUtils'
 
 export function useStreakData(studentId, activities, orgId) {
   // Only wave-enabled activities need streak calculation
@@ -51,38 +52,4 @@ export function useStreakData(studentId, activities, orgId) {
     enabled: !!studentId && !!orgId && activityIds.length > 0,
     staleTime: 5 * 60 * 1000, // 5 minutes
   })
-}
-
-function calculateStreak(activity, waveDates, schoolDaySet, asOfDate) {
-  let streak = 0
-  let checkDate = new Date(asOfDate)
-
-  for (let i = 0; i < 365; i++) {
-    const dateStr = formatDateISO(checkDate)
-
-    if (!schoolDaySet.has(dateStr)) {
-      // Non-school day — skip without breaking
-      checkDate = subDays(checkDate, 1)
-      continue
-    }
-
-    // Check if activity meets on this day (day-of-week check)
-    if (activity.days_of_week != null) {
-      const dow = checkDate.getDay()
-      if (!activity.days_of_week.includes(dow)) {
-        checkDate = subDays(checkDate, 1)
-        continue
-      }
-    }
-
-    // School day, activity meets — did the student wave?
-    if (!waveDates.has(dateStr)) {
-      break // Streak broken
-    }
-
-    streak += 1
-    checkDate = subDays(checkDate, 1)
-  }
-
-  return streak
 }

--- a/src/hooks/useStudentInstanceDetail.js
+++ b/src/hooks/useStudentInstanceDetail.js
@@ -1,0 +1,46 @@
+import { useQuery } from '@tanstack/react-query'
+import { getStudentInstanceDetail, getWaveHistory } from '@/api/agenda'
+import { getSchoolDays } from '@/api/calendar'
+import { formatDateISO, subDays } from '@/lib/scheduleUtils'
+import { calculateStreak } from '@/lib/streakUtils'
+
+export function useStudentInstanceDetail(studentId, instanceId, activity, orgId) {
+  return useQuery({
+    queryKey: ['student-instance-detail', studentId, instanceId],
+    queryFn: async () => {
+      const detail = await getStudentInstanceDetail(studentId, instanceId)
+
+      // Calculate streak if wave exists and activity info is available
+      let streak = 0
+      if (detail.wave && activity && orgId) {
+        const today = new Date()
+        const sinceDate = formatDateISO(subDays(today, 90))
+        const todayStr = formatDateISO(today)
+
+        const [waves, schoolDays] = await Promise.all([
+          getWaveHistory(studentId, [activity.id], sinceDate),
+          getSchoolDays(orgId, sinceDate, todayStr),
+        ])
+
+        const schoolDaySet = new Set(
+          schoolDays
+            .filter((sd) => sd.is_school_day)
+            .map((sd) => sd.date)
+        )
+
+        // Group wave dates for this activity
+        const waveDates = new Set()
+        for (const wave of waves) {
+          if (wave.activity_instance) {
+            waveDates.add(wave.activity_instance.date)
+          }
+        }
+
+        streak = calculateStreak(activity, waveDates, schoolDaySet, today)
+      }
+
+      return { ...detail, streak }
+    },
+    enabled: !!studentId && !!instanceId,
+  })
+}

--- a/src/hooks/useTeacherActionSummary.js
+++ b/src/hooks/useTeacherActionSummary.js
@@ -1,0 +1,79 @@
+import { useQuery } from '@tanstack/react-query'
+import { formatDateISO } from '@/lib/scheduleUtils'
+import {
+  getInstancesForActivities,
+  getWavesForInstances,
+  getCheckInsForInstances,
+  getStatusUpdatesForInstances,
+} from '@/api/agenda'
+
+export function useTeacherActionSummary(activityIds, date, orgId) {
+  const dateStr = formatDateISO(date)
+  const sortedKey = [...activityIds].sort().join(',')
+
+  return useQuery({
+    queryKey: ['teacher-action-summary', sortedKey, dateStr],
+    queryFn: async () => {
+      // 1. Get instance IDs
+      const instanceMap = await getInstancesForActivities(orgId, dateStr, activityIds)
+      const instanceIds = [...instanceMap.values()]
+
+      if (instanceIds.length === 0) {
+        return {
+          waveCounts: new Map(),
+          waves: new Map(),
+          checkIns: new Map(),
+          statusCounts: new Map(),
+          instances: instanceMap,
+        }
+      }
+
+      // 2. Fetch all action data in parallel
+      const [wavesData, checkInsData, statusData] = await Promise.all([
+        getWavesForInstances(instanceIds),
+        getCheckInsForInstances(instanceIds),
+        getStatusUpdatesForInstances(instanceIds),
+      ])
+
+      // Build reverse map: instanceId → activityId
+      const instanceToActivity = new Map()
+      for (const [activityId, instanceId] of instanceMap) {
+        instanceToActivity.set(instanceId, activityId)
+      }
+
+      // Wave counts per activity (for cards)
+      const waveCounts = new Map()
+      // Waves per student+activity (for roster icons)
+      const waves = new Map()
+      for (const w of wavesData) {
+        const actId = instanceToActivity.get(w.activity_instance_id)
+        if (actId) {
+          waveCounts.set(actId, (waveCounts.get(actId) ?? 0) + 1)
+          waves.set(`${w.student_id}-${actId}`, w)
+        }
+      }
+
+      // Check-ins per student+activity (for roster icons)
+      const checkIns = new Map()
+      for (const ci of checkInsData) {
+        const actId = instanceToActivity.get(ci.activity_instance_id)
+        if (actId) {
+          checkIns.set(`${ci.student_id}-${actId}`, ci)
+        }
+      }
+
+      // Status update counts per student+activity (for roster icons)
+      const statusCounts = new Map()
+      for (const s of statusData) {
+        const actId = instanceToActivity.get(s.activity_instance_id)
+        if (actId) {
+          const key = `${s.student_id}-${actId}`
+          statusCounts.set(key, (statusCounts.get(key) ?? 0) + 1)
+        }
+      }
+
+      return { waveCounts, waves, checkIns, statusCounts, instances: instanceMap }
+    },
+    enabled: activityIds.length > 0 && !!orgId,
+  })
+}

--- a/src/lib/streakUtils.js
+++ b/src/lib/streakUtils.js
@@ -1,0 +1,41 @@
+import { formatDateISO, subDays } from '@/lib/scheduleUtils'
+
+/**
+ * Calculate the current wave streak for an activity.
+ * Walks backward from asOfDate, skipping non-school days and days the
+ * activity doesn't meet (by day-of-week). Streak breaks on the first
+ * school day where the activity meets but no wave exists.
+ */
+export function calculateStreak(activity, waveDates, schoolDaySet, asOfDate) {
+  let streak = 0
+  let checkDate = new Date(asOfDate)
+
+  for (let i = 0; i < 365; i++) {
+    const dateStr = formatDateISO(checkDate)
+
+    if (!schoolDaySet.has(dateStr)) {
+      // Non-school day — skip without breaking
+      checkDate = subDays(checkDate, 1)
+      continue
+    }
+
+    // Check if activity meets on this day (day-of-week check)
+    if (activity.days_of_week != null) {
+      const dow = checkDate.getDay()
+      if (!activity.days_of_week.includes(dow)) {
+        checkDate = subDays(checkDate, 1)
+        continue
+      }
+    }
+
+    // School day, activity meets — did the student wave?
+    if (!waveDates.has(dateStr)) {
+      break // Streak broken
+    }
+
+    streak += 1
+    checkDate = subDays(checkDate, 1)
+  }
+
+  return streak
+}

--- a/src/pages/teacher/Dashboard.jsx
+++ b/src/pages/teacher/Dashboard.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import useAuthStore from '@/store/authStore'
 import { useTeacherAgenda } from '@/hooks/useTeacherAgenda'
+import { useTeacherActionSummary } from '@/hooks/useTeacherActionSummary'
 import { useOrgSettings } from '@/hooks/useOrgSettings'
 import { useDefaultScheduleTemplate } from '@/hooks/useScheduleTemplate'
 import { ensureActivityInstances } from '@/api/agenda'
@@ -28,6 +29,13 @@ function Dashboard() {
     useTeacherAgenda(teacherId, date, orgId)
   const { data: orgSettings } = useOrgSettings(orgId)
   const { data: template } = useDefaultScheduleTemplate(orgId)
+
+  // Action summary for wave counts on cards and icons in roster
+  const allActivityIds = useMemo(
+    () => activities.map((a) => a.id),
+    [activities]
+  )
+  const { data: actionSummary } = useTeacherActionSummary(allActivityIds, date, orgId)
 
   // Instance upsert (fire-and-forget)
   useEffect(() => {
@@ -150,14 +158,24 @@ function Dashboard() {
         day: 'numeric',
       })
 
-  // Render card function
-  const renderCard = (item) => (
-    <TeacherActivityCard
-      item={item}
-      blockLabels={blockLabels}
-      onClick={() => handleCardClick(item)}
-    />
-  )
+  // Render card function with wave counts
+  const renderCard = (item) => {
+    const waveCount = item.isAggregate
+      ? item.activities.reduce(
+          (sum, a) => sum + (actionSummary?.waveCounts?.get(a.id) ?? 0),
+          0
+        )
+      : (actionSummary?.waveCounts?.get(item.id) ?? 0)
+
+    return (
+      <TeacherActivityCard
+        item={item}
+        blockLabels={blockLabels}
+        waveCount={waveCount}
+        onClick={() => handleCardClick(item)}
+      />
+    )
+  }
 
   function handleCardClick(item) {
     if (item.isAggregate) {
@@ -248,6 +266,7 @@ function Dashboard() {
           orgId={orgId}
           teacherId={teacherId}
           blockLabels={blockLabels}
+          actionSummary={actionSummary}
           onClose={() => setRosterTarget(null)}
         />
       )}


### PR DESCRIPTION
## Summary

- **Condensed teacher activity cards** to two-row layout, merging enrollment count and wave count (👋) into the meta line
- **Redesigned roster modal rows** with an icon zone showing wave indicators, check-in/out status, geofence failures, and status update counts between student name and PAET buttons
- **Built StudentDetailOverlay** — a focused detail modal that opens on roster row click, showing full check-in timestamps, wave + streak info, and status update content
- **New hooks:** `useTeacherActionSummary` (batch-fetches action data for all students on a date) and `useStudentInstanceDetail` (fetches full detail for one student on overlay open)
- **Extracted streak calculation** into shared `streakUtils.js` used by both student and teacher hooks
- **Roster styling improvements:** zebra striping, individually rounded attendance buttons (replacing `join` pattern), clickable rows with `stopPropagation` on PAET zone

## Test plan

- [x] Teacher Dashboard loads with wave counts on activity cards (single and aggregate)
- [x] Cards with no waves omit the wave indicator entirely
- [x] Roster modal shows icons for students who have waved, checked in/out, or posted status updates
- [ ] Geofence failure icon (red) only appears when `geofence_validated = false`, not `null`
- [x] Clicking a roster row opens the StudentDetailOverlay with correct student data
- [x] Detail overlay shows check-in, wave/streak, and status update sections conditionally
- [x] Empty state shows "No activity recorded for this date." when student has no interactions
- [x] PAET buttons still work correctly (clicking them does NOT open the detail overlay)
- [x] Attendance save flow still works end-to-end
- [x] Aggregate roster shows activity name per row (without location)
- [ ] Verify build passes: `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)