### PR TITLE
feat: activity deletion with confirmation dialog

### DIFF
--- a/src/api/activities.js
+++ b/src/api/activities.js
@@ -67,6 +67,16 @@ export async function createActivity(activity) {
   return data
 }
 
+// Delete an activity (hard delete — all FKs cascade)
+export async function deleteActivity(activityId) {
+  const { error } = await supabase
+    .from('activities')
+    .delete()
+    .eq('id', activityId)
+
+  if (error) throw error
+}
+
 // Update an activity
 export async function updateActivity(activityId, updates) {
   const { data, error } = await supabase

--- a/src/components/activities/ActivityDetail.jsx
+++ b/src/components/activities/ActivityDetail.jsx
@@ -4,6 +4,7 @@ import {
   FaPencilAlt, FaCheck, FaTimes, FaUserPlus,
   FaClipboardList, FaClock, FaHandPaper, FaTags,
   FaMapMarkerAlt, FaDoorOpen, FaCalendarTimes, FaUserGraduate,
+  FaTrash,
 } from 'react-icons/fa'
 import { getBlocks, getBlockLabel, WEEKDAYS } from '@/lib/constants'
 import { useStaffUsers } from '@/hooks/useUsers'
@@ -119,6 +120,7 @@ export default function ActivityDetail({
   activity = null,
   mode = 'view',
   saving = false,
+  deleting = false,
   orgSettings = {},
   enrollments = [],
   defaultTemplate = null,
@@ -129,6 +131,7 @@ export default function ActivityDetail({
   onCancel,
   onEditClick,
   onEnrollClick,
+  onDelete,
 }) {
   const profile = useAuthStore((s) => s.profile)
   const orgId = orgIdProp || profile?.organization_id
@@ -146,6 +149,7 @@ export default function ActivityDetail({
   const [staffRows, setStaffRows] = useState(() => buildStaffRows(activity))
   const [showDescription, setShowDescription] = useState(!!(activity?.description))
   const [pendingTerms, setPendingTerms] = useState([])
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
   // Reset form, staff rows, and pending terms when activity changes
   useEffect(() => {
@@ -153,6 +157,7 @@ export default function ActivityDetail({
     setStaffRows(buildStaffRows(activity))
     setShowDescription(!!(activity?.description))
     setPendingTerms([])
+    setShowDeleteConfirm(false)
   }, [activity?.id ?? 'new']) // eslint-disable-line react-hooks/exhaustive-deps
 
   const watchedIsNotScheduled = watch('is_not_scheduled')
@@ -477,6 +482,51 @@ export default function ActivityDetail({
       {/* ── Roster section — only for existing activities ── */}
       {activity?.id && (
         <RosterSection enrollments={enrollments} onEnrollClick={onEnrollClick} />
+      )}
+
+      {/* ── Delete — only for existing activities in edit mode ── */}
+      {mode === 'edit' && activity?.id && onDelete && (
+        <div className="border-t border-base-300 pt-4 mt-1">
+          {showDeleteConfirm ? (
+            <div className="bg-error/10 border border-error/30 rounded-lg p-3 space-y-2">
+              <p className="text-sm font-medium text-error">
+                Delete &ldquo;{activity.name}&rdquo;?
+              </p>
+              <p className="text-xs text-base-content/60">
+                This will permanently remove all associated enrollments, attendance records, and other data.
+              </p>
+              <div className="flex gap-2 pt-1">
+                <button
+                  type="button"
+                  className="btn btn-error btn-sm"
+                  disabled={deleting}
+                  onClick={() => onDelete(activity.id)}
+                >
+                  {deleting
+                    ? <span className="loading loading-spinner loading-xs" />
+                    : 'Delete permanently'
+                  }
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-sm"
+                  disabled={deleting}
+                  onClick={() => setShowDeleteConfirm(false)}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              className="btn btn-ghost btn-xs text-error/60 hover:text-error gap-1"
+              onClick={() => setShowDeleteConfirm(true)}
+            >
+              <FaTrash size={11} /> Delete activity
+            </button>
+          )}
+        </div>
       )}
     </form>
   )

--- a/src/components/activities/ActivityDetailModal.jsx
+++ b/src/components/activities/ActivityDetailModal.jsx
@@ -23,6 +23,7 @@ export default function ActivityDetailModal({
   activity,
   isEditing,
   saving,
+  deleting,
   orgSettings,
   enrollments,
   defaultTemplate,
@@ -33,6 +34,7 @@ export default function ActivityDetailModal({
   onEditClick,
   onCancel,
   onSave,
+  onDelete,
   onEnrollClick,
 }) {
   // Close on Escape key
@@ -64,6 +66,7 @@ export default function ActivityDetailModal({
           activity={activity}
           mode={isEditing ? 'edit' : 'view'}
           saving={saving}
+          deleting={deleting}
           orgSettings={orgSettings}
           enrollments={enrollments ?? []}
           defaultTemplate={defaultTemplate}
@@ -73,6 +76,7 @@ export default function ActivityDetailModal({
           onSave={onSave}
           onCancel={onCancel}
           onEditClick={onEditClick}
+          onDelete={onDelete}
           onEnrollClick={onEnrollClick}
         />
       </div>

--- a/src/hooks/useActivities.js
+++ b/src/hooks/useActivities.js
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getActivities, createActivity, updateActivity } from '@/api/activities'
+import { getActivities, createActivity, updateActivity, deleteActivity } from '@/api/activities'
 
 export function useActivities(orgId) {
   return useQuery({
@@ -25,6 +25,17 @@ export function useUpdateActivity(orgId) {
 
   return useMutation({
     mutationFn: ({ id, updates }) => updateActivity(id, updates),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['activities', orgId] })
+    },
+  })
+}
+
+export function useDeleteActivity(orgId) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (activityId) => deleteActivity(activityId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['activities', orgId] })
     },

--- a/src/pages/admin/ActivityManagement.jsx
+++ b/src/pages/admin/ActivityManagement.jsx
@@ -6,7 +6,7 @@ import ActivityDetailModal from '@/components/activities/ActivityDetailModal'
 import BulkEditModal from '@/components/activities/BulkEditModal'
 import FloatingPanel from '@/components/panels/FloatingPanel'
 import EnrollmentPanel from '@/components/enrollment/EnrollmentPanel'
-import { useActivities, useCreateActivity, useUpdateActivity } from '@/hooks/useActivities'
+import { useActivities, useCreateActivity, useUpdateActivity, useDeleteActivity } from '@/hooks/useActivities'
 import { addActivityTerm } from '@/api/activityTerms'
 import { useOrgEnrollments, useActivityEnrollments } from '@/hooks/useEnrollments'
 import { useOrgSettings } from '@/hooks/useOrgSettings'
@@ -38,6 +38,7 @@ function ActivityManagement() {
   const { data: staffUsers = [] } = useStaffUsers(orgId)
   const createMutation = useCreateActivity(orgId)
   const updateMutation = useUpdateActivity(orgId)
+  const deleteMutation = useDeleteActivity(orgId)
 
   // Modal state
   const [modalOpen, setModalOpen] = useState(false)
@@ -170,7 +171,8 @@ function ActivityManagement() {
   const hasActiveFilters = searchQuery.trim() || Object.values(filters).some((v) => v !== 'all')
 
   const saving = createMutation.isPending || updateMutation.isPending
-  const mutationError = createMutation.error || updateMutation.error
+  const deleting = deleteMutation.isPending
+  const mutationError = createMutation.error || updateMutation.error || deleteMutation.error
   const error = loadError?.message || mutationError?.message
 
   // ── Handlers ──────────────────────────────────────────────────────────────
@@ -193,6 +195,15 @@ function ActivityManagement() {
     setSelectedActivity(null)
     createMutation.reset()
     updateMutation.reset()
+    deleteMutation.reset()
+  }
+
+  function handleDelete(activityId) {
+    deleteMutation.mutate(activityId, {
+      onSuccess: () => {
+        handleCloseModal()
+      },
+    })
   }
 
   function handleEditClick() {
@@ -297,7 +308,7 @@ function ActivityManagement() {
           <span>{error}</span>
           <button
             className="btn btn-ghost btn-sm"
-            onClick={() => { createMutation.reset(); updateMutation.reset() }}
+            onClick={() => { createMutation.reset(); updateMutation.reset(); deleteMutation.reset() }}
           >
             ✕
           </button>
@@ -350,6 +361,7 @@ function ActivityManagement() {
         activity={selectedActivity}
         isEditing={isEditing}
         saving={saving}
+        deleting={deleting}
         orgSettings={orgSettings}
         enrollments={activityEnrollments}
         defaultTemplate={defaultTemplate}
@@ -360,6 +372,7 @@ function ActivityManagement() {
         onEditClick={handleEditClick}
         onCancel={handleCancel}
         onSave={handleSave}
+        onDelete={handleDelete}
         onEnrollClick={handleEnrollClick}
       />
 


### PR DESCRIPTION
Closes #38

Adds hard delete for activities from the edit view, with an inline confirmation dialog that names the activity. No migration needed — all FK cascades were already in place.

Generated with [Claude Code](https://claude.ai/code)