### PR TITLE
fix: resolve cross-month date range save error (issue #12)

### DIFF
--- a/src/components/school-calendar/CalendarGrid.jsx
+++ b/src/components/school-calendar/CalendarGrid.jsx
@@ -213,8 +213,16 @@ export default function CalendarGrid({ orgId, orgSettings, terms }) {
 
   async function handleMarkRange(startDateStr, endDateStr, reason, notes) {
     const weekdays = getWeekdaysInRange(startDateStr, endDateStr)
+
+    // Fetch existing records for the full range — schoolDayMap only covers the current
+    // month view, so a cross-month range would produce a mixed batch (some rows with id,
+    // some without). PostgREST normalizes mixed batches by setting missing id to null,
+    // which violates the NOT NULL constraint. Fetching the full range gives us consistent ids.
+    const existingInRange = await getSchoolDays(orgId, startDateStr, endDateStr)
+    const existingRangeMap = new Map(existingInRange.map(d => [d.date, d]))
+
     const rows = weekdays.map(date => {
-      const existing = schoolDayMap.get(date)
+      const existing = existingRangeMap.get(date)
       return {
         organization_id: orgId,
         date,


### PR DESCRIPTION
Fixes #12

## Problem

When marking a schedule exception over a range that crosses a month boundary (e.g. Dec 22–Jan 2), the save fails with a NOT NULL constraint violation on the `id` column of `school_days`.

`schoolDayMap` only holds records for the currently-viewed month. A cross-month range produced a mixed upsert batch: in-view-month dates carried their DB `id`, but the other-month dates did not. PostgREST requires all rows in a batch to have the same column set and normalizes missing `id` values to `null`, triggering the constraint error.

## Fix

Fetch existing `school_days` for the full requested range before building the upsert rows. Every row that already has a DB record now carries its real `id`, making the batch uniform regardless of which months the range spans.

Generated with [Claude Code](https://claude.ai/code)