### PR TITLE
fix: wave badge animation plays twice then stops on teacher agenda cards

### DIFF
--- a/src/components/agenda/TeacherActivityCard.jsx
+++ b/src/components/agenda/TeacherActivityCard.jsx
@@ -44,7 +44,7 @@ function SingleCard({ item, blockLabels, waveCount, onClick }) {
           {metaLine && <>{metaLine} &middot; </>}
           <span>{count}</span>
           {waveCount > 0 && (
-            <span className="ml-1.5 inline-flex items-center gap-0.5 animate-bounce">
+            <span className="ml-1.5 inline-flex items-center gap-0.5 wave-badge">
               <HandWaving size={14} />
               <span>{waveCount}</span>
             </span>
@@ -74,7 +74,7 @@ function AggregateCard({ item, blockLabels, waveCount, onClick }) {
           <span>{item.activityCount} activities</span>
           <span> &middot; {item.totalEnrollment}</span>
           {waveCount > 0 && (
-            <span className="ml-1.5 inline-flex items-center gap-0.5 animate-bounce">
+            <span className="ml-1.5 inline-flex items-center gap-0.5 wave-badge">
               <HandWaving size={14} />
               <span>{waveCount}</span>
             </span>

--- a/src/index.css
+++ b/src/index.css
@@ -92,6 +92,20 @@
   transition: transform 0.1s ease;
 }
 
+/* ── Wave badge on teacher agenda cards ─────────────────────── */
+@keyframes wave-badge-bounce {
+  0%   { transform: translateY(0); }
+  25%  { transform: translateY(-30%); }
+  50%  { transform: translateY(0); }
+  75%  { transform: translateY(-15%); }
+  100% { transform: translateY(0); }
+}
+
+.wave-badge {
+  animation: wave-badge-bounce 0.8s ease 2;
+  animation-fill-mode: forwards;
+}
+
 /* ── Pulse ring on available action buttons ──────────────────── */
 .pulse-available {
   position: relative;


### PR DESCRIPTION
Replaces the infinite `animate-bounce` Tailwind class with a custom `.wave-badge` CSS class that plays a bounce animation exactly twice then stops. Applies to both SingleCard and AggregateCard in TeacherActivityCard.jsx.

Closes #73

Generated with [Claude Code](https://claude.ai/code)