### PR TITLE
feat: add getViewerRole staff role derivation helper

### DIFF
--- a/src/lib/staffRoles.js
+++ b/src/lib/staffRoles.js
@@ -1,0 +1,48 @@
+/**
+ * Staff role derivation utilities.
+ *
+ * Single source of truth for answering: "what is this viewer's role on
+ * this activity?" Consumers should never compare viewer ids against
+ * `teacher_id` / `monitor_id` directly — always go through these helpers.
+ *
+ * Pre-#70 (current): role is derived from `activities.teacher_id` and
+ * `activities.monitor_id` columns.
+ *
+ * Post-#70: role is derived from the `activity_staff` junction table.
+ * When that migration lands, update this file's internals only. The
+ * exported function signatures stay the same.
+ *
+ * See: docs/user-flows/role-derivation-helper-build-spec.md
+ * See: GitHub #70 (activity_staff junction table)
+ */
+
+/**
+ * Derive the viewer's role on a given activity.
+ *
+ * Today, role is determined by comparing the viewer's id against
+ * `activities.teacher_id` and `activities.monitor_id`. When #70 lands
+ * and replaces those columns with the `activity_staff` junction table,
+ * the body of this function changes to look up the viewer's row in
+ * `activity.activity_staff` and return its `role` field. The function
+ * signature and return type stay the same.
+ *
+ * @param {object} activity - An activity record. Must include `teacher_id`
+ *   and `monitor_id` fields (pre-#70). Post-#70, must include
+ *   `activity_staff` array.
+ * @param {string} viewerId - The current user's profile id.
+ * @returns {'teacher' | 'monitor' | null}
+ *   - `'teacher'` if the viewer is listed as the activity's teacher
+ *   - `'monitor'` if the viewer is listed as the activity's monitor
+ *   - `null` if the viewer has no staff role on this activity
+ *     (e.g. viewing a visible-to-all activity they're not assigned to)
+ *
+ * @example
+ *   const role = getViewerRole(activity, profile.id)
+ *   if (role === 'teacher') { ... }
+ */
+export function getViewerRole(activity, viewerId) {
+  if (!activity || !viewerId) return null
+  if (activity.teacher_id === viewerId) return 'teacher'
+  if (activity.monitor_id === viewerId) return 'monitor'
+  return null
+}


### PR DESCRIPTION
## Summary

- Adds `src/lib/staffRoles.js` — a single-source-of-truth utility for answering "what is this viewer's role on this activity?"
- Exports `getViewerRole(activity, viewerId)` returning `'teacher' | 'monitor' | null`
- Module header documents the pre-#70 / post-#70 migration plan; when #70 ships the `activity_staff` junction table, only this file's internals change

## Why now

#86 (teacher agenda rewrite) needs to make layout and color decisions based on the viewer's staff role. By introducing this helper before #86 builds, the agenda can consume a stable interface from day one rather than comparing raw `teacher_id` / `monitor_id` fields directly.

## Related

- Part of #86 foundation work
- Seam for #70 (`activity_staff` junction table) — see module header

## Test plan

- [ ] Import `getViewerRole` and call with an activity where `teacher_id` matches viewer → returns `'teacher'`
- [ ] Call with `monitor_id` match → returns `'monitor'`
- [ ] Call with no match → returns `null`
- [ ] Call with `null` activity or `null` viewerId → returns `null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)