### PR TITLE
feat: add visible_to_all_staff flag to activities

### DIFF
--- a/src/components/activities/ActivityDetail.jsx
+++ b/src/components/activities/ActivityDetail.jsx
@@ -4,7 +4,7 @@ import {
   PencilSimple, Check, X,
   ClipboardText, HandWaving, ListChecks,
   MapPin, DoorOpen, CalendarX, Student,
-  Trash, CheckCircle, Gps, GpsFix,
+  Trash, CheckCircle, Gps, GpsFix, UsersThree,
 } from '@phosphor-icons/react'
 import { searchAddress } from '@/lib/nominatimSearch'
 import { getBlocks, getBlockLabel, DAYS_OF_WEEK, WEEKDAYS } from '@/lib/constants'
@@ -28,6 +28,7 @@ const BEHAVIOR_FLAGS = [
   { field: 'requires_geofence',    icon: MapPin,        tooltip: 'Requires geofence' },
   { field: 'is_release',           icon: DoorOpen,      tooltip: 'Release (no attendance)' },
   { field: 'is_not_scheduled',     icon: CalendarX,     tooltip: 'Not scheduled' },
+  { field: 'visible_to_all_staff', icon: UsersThree,    tooltip: 'Visible to all staff' },
 ]
 
 // ─── Form value helpers ────────────────────────────────────────────────────────
@@ -54,6 +55,7 @@ const DEFAULT_VALUES = {
   requires_geofence: false,
   is_release: false,
   is_not_scheduled: false,
+  visible_to_all_staff: false,
   calendar_id: null,
   recurrence_interval: 1,
   starting_week: 1,
@@ -103,6 +105,7 @@ function buildInitialValues(activity) {
     requires_geofence: activity.requires_geofence ?? false,
     is_release: activity.is_release ?? false,
     is_not_scheduled: activity.is_not_scheduled ?? false,
+    visible_to_all_staff: activity.visible_to_all_staff ?? false,
     calendar_id: activity.calendar_id ?? null,
     recurrence_interval: activity.recurrence_interval ?? 1,
     starting_week: deriveStartingWeek(activity.recurrence_anchor_date, activity.start_date),
@@ -312,6 +315,7 @@ export default function ActivityDetail({
       requires_geofence: formValues.requires_geofence,
       is_release: formValues.is_release,
       is_not_scheduled: formValues.is_not_scheduled,
+      visible_to_all_staff: formValues.visible_to_all_staff,
       calendar_id: formValues.calendar_id || null,
       recurrence_interval: formValues.recurrence_interval,
       recurrence_anchor_date: computeAnchorDate(formValues.start_date, formValues.starting_week, formValues.recurrence_interval),

--- a/supabase/migrations/20260514000001_add_visible_to_all_staff.sql
+++ b/supabase/migrations/20260514000001_add_visible_to_all_staff.sql
@@ -1,0 +1,5 @@
+ALTER TABLE activities
+  ADD COLUMN visible_to_all_staff BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN activities.visible_to_all_staff IS
+  'When true, this activity surfaces in every teacher''s agenda sidebar for situational awareness, regardless of staff assignment. Used for open/independent study blocks where students are dispersed across the building.';


### PR DESCRIPTION
## Summary

- Migration: adds `visible_to_all_staff BOOLEAN NOT NULL DEFAULT false` to `activities` with a column comment
- `ActivityDetail`: adds the flag to `BEHAVIOR_FLAGS` (with `UsersThree` Phosphor icon), `DEFAULT_VALUES`, `buildInitialValues`, and `onFormSubmit` — follows the exact same pattern as all other behavior flags

## Why

City View operates as "one big room" — some activities (open/independent study blocks) should be visible to all staff for situational awareness regardless of assignment. This flag is the data trigger for the teacher agenda sidebar being built in #86. Shipping it standalone lets #86 build against a real column rather than a placeholder.

## What this is not

The sidebar itself. Without #86 consuming this flag, it has no user-visible behavior beyond the icon appearing in the activity detail form. That is expected and correct.

## Related

- Feeds #86 (teacher agenda sidebar)
- Originally scoped as part of #70; extracted here so #86 doesn't block on the full `activity_staff` migration

## Test plan

- [ ] Run migration
- [ ] Create activity, leave icon inactive → `visible_to_all_staff = false` in DB
- [ ] Create activity, toggle icon active → `visible_to_all_staff = true` in DB
- [ ] Edit existing activity, toggle, save → value updates
- [ ] View mode → icon reflects persisted state (no regression in other behavior flags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)