### PR TITLE
feat: add start_time_override / end_time_override to enrollments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2389,13 +2389,13 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-8.0.0.tgz",
-      "integrity": "sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 20"
       }
     },
     "node_modules/ajv": {
@@ -3246,17 +3246,17 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-8.0.0.tgz",
-      "integrity": "sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
+      "integrity": "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "8.0.0",
+        "agent-base": "9.0.0",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 20"
       }
     },
     "node_modules/iceberg-js": {
@@ -3970,9 +3970,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -4267,15 +4267,15 @@
       }
     },
     "node_modules/supabase": {
-      "version": "2.84.5",
-      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.84.5.tgz",
-      "integrity": "sha512-quguD5MJVcbbMie35d++BaV3ejXyTTZQIz3zH/z485bLxcEl+wC1EttGboq9Snukzv6sDoQkshXYga+6K4SQwA==",
+      "version": "2.98.2",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.98.2.tgz",
+      "integrity": "sha512-COSz57JyuUGbj75GSGM5mmyz/behBiYSiJ4A9qJVVC/vNp9bYS+9RCTXBtEt8kgqDDYWZsOmzk+mPbIBdr9bPg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bin-links": "^6.0.0",
-        "https-proxy-agent": "^8.0.0",
+        "https-proxy-agent": "^9.0.0",
         "node-fetch": "^3.3.2",
         "tar": "7.5.13"
       },

--- a/src/api/agenda.js
+++ b/src/api/agenda.js
@@ -127,7 +127,7 @@ export async function getTeacherActivitiesForDate(teacherId, orgId) {
 export async function getRosterForActivities(activityIds) {
   const { data, error } = await supabase
     .from('enrollments')
-    .select('id, activity_id, student_id, block, days_of_week, rotation_day_type, recurrence_interval, recurrence_anchor_date, student:student_id(id, first_name, last_name, preferred_name, grade_level)')
+    .select('id, activity_id, student_id, block, days_of_week, rotation_day_type, recurrence_interval, recurrence_anchor_date, start_time_override, end_time_override, student:student_id(id, first_name, last_name, preferred_name, grade_level)')
     .in('activity_id', activityIds)
     .eq('is_active', true)
 

--- a/src/api/enrollments.js
+++ b/src/api/enrollments.js
@@ -78,6 +78,7 @@ export async function getOrgEnrollments(organizationId) {
     .select(`
       id, student_id, activity_id, block, is_active,
       days_of_week, rotation_day_type, recurrence_interval, recurrence_anchor_date,
+      start_time_override, end_time_override,
       activity:activities!inner(
         id, name, block, days_of_week, rotation_day_type,
         default_start_time, default_end_time,

--- a/src/components/activities/ActivityDetail.jsx
+++ b/src/components/activities/ActivityDetail.jsx
@@ -1468,7 +1468,7 @@ function EnrollmentStudentRow({
   onToggleExpand, onScheduleChange, onScheduleSave, onScheduleCancel,
 }) {
   const isPendingUnenroll = student.pendingUnenroll
-  const canEdit = zone === 'enrolled' && !student.isNewlyStaged && !isPendingUnenroll && enrollment && activity?.days_of_week?.length > 0
+  const canEdit = zone === 'enrolled' && !student.isNewlyStaged && !isPendingUnenroll && enrollment
 
   // Compute collapsed schedule summary from current enrollment fields (or local draft)
   const effectiveEnrollment = localSchedule
@@ -1555,8 +1555,10 @@ function getEnrollmentScheduleSummary(enrollment, activity) {
   const hasDays = enrollment.days_of_week != null
   const hasRotation = enrollment.rotation_day_type != null
   const hasRecurrence = enrollment.recurrence_interval != null && enrollment.recurrence_interval > 1
+  const hasStartOverride = enrollment.start_time_override != null
+  const hasEndOverride = enrollment.end_time_override != null
 
-  if (!hasDays && !hasRotation && !hasRecurrence) return null
+  if (!hasDays && !hasRotation && !hasRecurrence && !hasStartOverride && !hasEndOverride) return null
 
   const parts = []
   if (hasRecurrence) parts.push(`Every ${enrollment.recurrence_interval} wks`)
@@ -1567,6 +1569,8 @@ function getEnrollmentScheduleSummary(enrollment, activity) {
       .join(' ')
     parts.push(labels)
   }
+  if (hasStartOverride) parts.push(`arr ${formatTime(enrollment.start_time_override)}`)
+  if (hasEndOverride) parts.push(`leaves ${formatTime(enrollment.end_time_override)}`)
   return parts.join(' · ') || null
 }
 
@@ -1712,6 +1716,61 @@ function EnrollmentScheduleEditor({ enrollment, activity, orgSettings, localSche
           )}
         </div>
       </div>
+
+      {/* Arrival / departure overrides */}
+      {(activity?.default_start_time || activity?.default_end_time) && (
+        <div className="border-l-2 border-warning/40 pl-2">
+          <div className="text-warning/70 mb-1">Arrival / departure overrides</div>
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <span className="text-base-content/50 w-12 shrink-0">Arrives</span>
+              <input
+                type="time"
+                className="input input-xs input-bordered w-28"
+                value={localSchedule.start_time_override ?? (enrollment.start_time_override ?? '')}
+                onChange={(e) => onChange('start_time_override', e.target.value || null)}
+              />
+              {activity?.default_start_time && (
+                <span className="text-base-content/30 text-xs">(default: {formatTime(activity.default_start_time)})</span>
+              )}
+              {(localSchedule.start_time_override !== undefined
+                ? localSchedule.start_time_override
+                : enrollment.start_time_override) != null && (
+                <button
+                  type="button"
+                  className="btn btn-xs btn-ghost text-base-content/40"
+                  onClick={() => onChange('start_time_override', null)}
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-base-content/50 w-12 shrink-0">Leaves</span>
+              <input
+                type="time"
+                className="input input-xs input-bordered w-28"
+                value={localSchedule.end_time_override ?? (enrollment.end_time_override ?? '')}
+                onChange={(e) => onChange('end_time_override', e.target.value || null)}
+              />
+              {activity?.default_end_time && (
+                <span className="text-base-content/30 text-xs">(default: {formatTime(activity.default_end_time)})</span>
+              )}
+              {(localSchedule.end_time_override !== undefined
+                ? localSchedule.end_time_override
+                : enrollment.end_time_override) != null && (
+                <button
+                  type="button"
+                  className="btn btn-xs btn-ghost text-base-content/40"
+                  onClick={() => onChange('end_time_override', null)}
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Save / Cancel */}
       <div className="flex gap-2 pt-1">

--- a/supabase/migrations/20260514000002_add_enrollment_time_overrides.sql
+++ b/supabase/migrations/20260514000002_add_enrollment_time_overrides.sql
@@ -1,0 +1,9 @@
+ALTER TABLE enrollments
+  ADD COLUMN start_time_override TIME,
+  ADD COLUMN end_time_override TIME;
+
+COMMENT ON COLUMN enrollments.start_time_override IS
+  'Optional per-enrollment override of the activity''s default_start_time. When set, the teacher agenda displays this student as scheduled to arrive at this time. Informational — does not gate attendance.';
+
+COMMENT ON COLUMN enrollments.end_time_override IS
+  'Optional per-enrollment override of the activity''s default_end_time. Symmetric counterpart to start_time_override. Used less often but cheap to maintain.';


### PR DESCRIPTION
## Summary

- Migration: adds `start_time_override TIME` and `end_time_override TIME` to `enrollments`, both nullable with column comments
- `EnrollmentScheduleEditor`: new "Arrival / departure overrides" section with time inputs and Clear buttons, amber accent, conditional on the activity having default times
- `getEnrollmentScheduleSummary`: extended with `arr H:MM` / `leaves H:MM` parts when overrides are set
- `canEdit` gate: dropped the `days_of_week.length > 0` requirement — editor now opens for rotation-based and fully-unscheduled activities
- `getRosterForActivities` (`agenda.js`): added both columns to explicit select list
- `getOrgEnrollments` (`enrollments.js`): added both columns to explicit select list (caught during testing — the cache was missing the values after save)

## What this is not

Teacher-facing display. A teacher loading their agenda after this ships sees no visual difference. The late-arrival chip and "Arriving later" roster section are in #86.

## Related

- Data layer of #87
- Will be consumed by #86 (teacher agenda)

## Test plan

- [x] Run migration
- [x] Open enrollment editor on activity **with** default times → override section visible
- [x] Open enrollment editor on activity **without** default times → section hidden
- [x] Open enrollment editor on rotation-based activity (no `days_of_week`) → editor opens (gate fix works)
- [x] Set arrival override, Save → collapsed row shows `arr H:MM`; reopen editor → input is populated
- [x] Clear override → summary drops the part
- [x] Set both overrides → summary shows both
- [x] Existing enrollments with no overrides → no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)